### PR TITLE
Upgrades to support Extending Tina

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/typography": "^0.5.0",
     "@tailwindcss/ui": "^0.7.2",
-    "@tinacms/cli": "^0.58.2",
+    "@tinacms/cli": "^0.60.12",
+    "@tinacms/schema-tools": "^0.0.3",
     "autoprefixer": "^10.4.0",
     "esbuild-wasm": "^0.14.2",
     "graphql": "16.1.0",
@@ -29,15 +30,15 @@
     "styled-components": "^5.3.3",
     "sucrase": "^3.20.3",
     "tailwindcss": "^3.0.0",
-    "tinacms": "0.66.2"
+    "tinacms": "^0.67.3"
   },
   "devDependencies": {
     "@types/react": "^17.0.33",
     "@types/react-dom": "^17.0.10",
     "@vitejs/plugin-react": "^1.0.7",
-    "vite-plugin-monaco-editor": "^1.0.10",
     "typescript": "^4.4.4",
-    "vite": "^2.7.2"
+    "vite": "^2.7.2",
+    "vite-plugin-monaco-editor": "^1.0.10"
   },
   "resolutions": {
     "react-datetime": "3.1.1"

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -152,10 +152,10 @@ export function Layout({
 
   const items = [
     {
-      name: ".tina/schema.ts",
+      name: ".tina/schema.tsx",
       render: (
         <BaseEditor
-          extension="ts"
+          extension="tsx"
           resetCounter={state.resetCounter}
           state={state}
           name={state.example.name}
@@ -218,7 +218,7 @@ export function Layout({
 
   const tabItems = [
     {
-      name: ".tina/schema.ts",
+      name: ".tina/schema.tsx",
     },
     {
       name: "posts/hello-world.md",
@@ -332,7 +332,7 @@ export class ErrorBoundary extends React.Component<
       );
     }
 
-    return this.props.children;
+    return <>{this.props.children}</>;
   }
 }
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -17,7 +17,7 @@ export async function executeCode<T extends unknown>(
   return esbuild
     .transform(code, {
       jsx: "transform",
-      loader: "jsx",
+      loader: "tsx",
       format: "cjs",
     })
     .then((meh) => {

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -56,12 +56,6 @@ export function Nav({
                 </div>
               </div>
               <div className="hidden lg:ml-4 lg:flex lg:items-center">
-                <button
-                  type="button"
-                  className="relative inline-flex items-center px-8 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                >
-                  <span>Share</span>
-                </button>
                 <Menu as="div" className="ml-4 relative inline-block text-left">
                   <div>
                     <Menu.Button className="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-blue-500">

--- a/src/editors/base-editor.tsx
+++ b/src/editors/base-editor.tsx
@@ -11,13 +11,21 @@ import { API_URL, fetcher } from "../fetcher";
 
 // These are manually copied over from @tinacms/graphql
 import tinatypes from "./types.d.ts?raw";
+import reactypes from "./react-types.d.ts?raw";
 
+monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+  jsx: monaco.languages.typescript.JsxEmit.React,
+});
 monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
 monaco.languages.typescript.typescriptDefaults.addExtraLib(
   `
-declare module '@tinacms/cli' {
+declare module 'tinacms' {
   ${tinatypes}
   export declare function defineSchema(obj: TinaCloudSchemaBase) : object
+}
+
+declare module 'react' {
+  ${reactypes}
 }
 `,
   "file:///node_modules/@tinacms/cli/index.d.ts"
@@ -36,7 +44,7 @@ export const BaseEditor = (props: {
   name: string;
   state: State;
   onUpdate: (code: string) => void;
-  extension: "jsx" | "md" | "graphql" | "ts";
+  extension: "jsx" | "md" | "graphql" | "ts" | "tsx";
 }) => {
   const monacoEl = useRef(null);
   const editor = React.useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -47,6 +55,8 @@ export const BaseEditor = (props: {
     ts: "typescript",
     md: "markdown",
     graphql: "graphql",
+    jsx: "javascript",
+    tsx: "typescript",
   };
   const language = languages[props.extension];
 

--- a/src/editors/react-types.d.ts
+++ b/src/editors/react-types.d.ts
@@ -1,0 +1,4147 @@
+// Type definitions for React 18.0
+// Project: http://facebook.github.io/react/
+// Definitions by: Asana <https://asana.com>
+//                 AssureSign <http://www.assuresign.com>
+//                 Microsoft <https://microsoft.com>
+//                 John Reilly <https://github.com/johnnyreilly>
+//                 Benoit Benezech <https://github.com/bbenezech>
+//                 Patricio Zavolinsky <https://github.com/pzavolinsky>
+//                 Eric Anderson <https://github.com/ericanderson>
+//                 Dovydas Navickas <https://github.com/DovydasNavickas>
+//                 Josh Rutherford <https://github.com/theruther4d>
+//                 Guilherme Hübner <https://github.com/guilhermehubner>
+//                 Ferdy Budhidharma <https://github.com/ferdaber>
+//                 Johann Rakotoharisoa <https://github.com/jrakotoharisoa>
+//                 Olivier Pascal <https://github.com/pascaloliv>
+//                 Martin Hochel <https://github.com/hotell>
+//                 Frank Li <https://github.com/franklixuefei>
+//                 Jessica Franco <https://github.com/Jessidhia>
+//                 Saransh Kataria <https://github.com/saranshkataria>
+//                 Kanitkorn Sujautra <https://github.com/lukyth>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
+//                 Kyle Scully <https://github.com/zieka>
+//                 Cong Zhang <https://github.com/dancerphil>
+//                 Dimitri Mitropoulos <https://github.com/dimitropoulos>
+//                 JongChan Choi <https://github.com/disjukr>
+//                 Victor Magalhães <https://github.com/vhfmag>
+//                 Dale Tan <https://github.com/hellatan>
+//                 Priyanshu Rav <https://github.com/priyanshurav>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+// NOTE: Users of the `experimental` builds of React should add a reference
+// to 'react/experimental' in their project. See experimental.d.ts's top comment
+// for reference and documentation on how exactly to do it.
+
+/// <reference path="global.d.ts" />
+
+import * as CSS from "csstype";
+import * as PropTypes from "prop-types";
+import { Interaction as SchedulerInteraction } from "scheduler/tracing";
+
+type NativeAnimationEvent = AnimationEvent;
+type NativeClipboardEvent = ClipboardEvent;
+type NativeCompositionEvent = CompositionEvent;
+type NativeDragEvent = DragEvent;
+type NativeFocusEvent = FocusEvent;
+type NativeKeyboardEvent = KeyboardEvent;
+type NativeMouseEvent = MouseEvent;
+type NativeTouchEvent = TouchEvent;
+type NativePointerEvent = PointerEvent;
+type NativeTransitionEvent = TransitionEvent;
+type NativeUIEvent = UIEvent;
+type NativeWheelEvent = WheelEvent;
+type Booleanish = boolean | "true" | "false";
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// Destructors are only allowed to return void.
+type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+// tslint:disable-next-line:export-just-namespace
+export = React;
+export as namespace React;
+
+declare namespace React {
+  //
+  // React Elements
+  // ----------------------------------------------------------------------
+
+  type ElementType<P = any> =
+    | {
+        [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K]
+          ? K
+          : never;
+      }[keyof JSX.IntrinsicElements]
+    | ComponentType<P>;
+  type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+
+  type JSXElementConstructor<P> =
+    | ((props: P) => ReactElement<any, any> | null)
+    | (new (props: P) => Component<any, any>);
+
+  interface RefObject<T> {
+    readonly current: T | null;
+  }
+  // Bivariance hack for consistent unsoundness with RefObject
+  type RefCallback<T> = {
+    bivarianceHack(instance: T | null): void;
+  }["bivarianceHack"];
+  type Ref<T> = RefCallback<T> | RefObject<T> | null;
+  type LegacyRef<T> = string | Ref<T>;
+  /**
+   * Gets the instance type for a React element. The instance will be different for various component types:
+   *
+   * - React class components will be the class instance. So if you had `class Foo extends React.Component<{}> {}`
+   *   and used `React.ElementRef<typeof Foo>` then the type would be the instance of `Foo`.
+   * - React stateless functional components do not have a backing instance and so `React.ElementRef<typeof Bar>`
+   *   (when `Bar` is `function Bar() {}`) will give you the `undefined` type.
+   * - JSX intrinsics like `div` will give you their DOM instance. For `React.ElementRef<'div'>` that would be
+   *   `HTMLDivElement`. For `React.ElementRef<'input'>` that would be `HTMLInputElement`.
+   * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
+   *   to component.
+   *
+   * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+   *
+   * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
+   *       `React.forwardRef()` returns.
+   */
+  type ElementRef<
+    C extends
+      | ForwardRefExoticComponent<any>
+      | { new (props: any): Component<any> }
+      | ((props: any, context?: any) => ReactElement | null)
+      | keyof JSX.IntrinsicElements
+  > =
+    // need to check first if `ref` is a valid prop for ts@3.0
+    // otherwise it will infer `{}` instead of `never`
+    "ref" extends keyof ComponentPropsWithRef<C>
+      ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends Ref<infer Instance>
+        ? Instance
+        : never
+      : never;
+
+  type ComponentState = any;
+
+  type Key = string | number;
+
+  /**
+   * @internal You shouldn't need to use this type since you never see these attributes
+   * inside your component or have to validate them.
+   */
+  interface Attributes {
+    key?: Key | null | undefined;
+  }
+  interface RefAttributes<T> extends Attributes {
+    ref?: Ref<T> | undefined;
+  }
+  interface ClassAttributes<T> extends Attributes {
+    ref?: LegacyRef<T> | undefined;
+  }
+
+  interface ReactElement<
+    P = any,
+    T extends string | JSXElementConstructor<any> =
+      | string
+      | JSXElementConstructor<any>
+  > {
+    type: T;
+    props: P;
+    key: Key | null;
+  }
+
+  interface ReactComponentElement<
+    T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
+    P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, "key" | "ref">>
+  > extends ReactElement<P, Exclude<T, number>> {}
+
+  interface FunctionComponentElement<P>
+    extends ReactElement<P, FunctionComponent<P>> {
+    ref?:
+      | ("ref" extends keyof P
+          ? P extends { ref?: infer R | undefined }
+            ? R
+            : never
+          : never)
+      | undefined;
+  }
+
+  type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<
+    P,
+    T
+  >;
+  interface ComponentElement<P, T extends Component<P, ComponentState>>
+    extends ReactElement<P, ComponentClass<P>> {
+    ref?: LegacyRef<T> | undefined;
+  }
+
+  type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
+
+  // string fallback for custom web-components
+  interface DOMElement<
+    P extends HTMLAttributes<T> | SVGAttributes<T>,
+    T extends Element
+  > extends ReactElement<P, string> {
+    ref: LegacyRef<T>;
+  }
+
+  // ReactHTML for ReactHTMLElement
+  interface ReactHTMLElement<T extends HTMLElement>
+    extends DetailedReactHTMLElement<AllHTMLAttributes<T>, T> {}
+
+  interface DetailedReactHTMLElement<
+    P extends HTMLAttributes<T>,
+    T extends HTMLElement
+  > extends DOMElement<P, T> {
+    type: keyof ReactHTML;
+  }
+
+  // ReactSVG for ReactSVGElement
+  interface ReactSVGElement
+    extends DOMElement<SVGAttributes<SVGElement>, SVGElement> {
+    type: keyof ReactSVG;
+  }
+
+  interface ReactPortal extends ReactElement {
+    key: Key | null;
+    children: ReactNode;
+  }
+
+  //
+  // Factories
+  // ----------------------------------------------------------------------
+
+  type Factory<P> = (
+    props?: Attributes & P,
+    ...children: ReactNode[]
+  ) => ReactElement<P>;
+
+  /**
+   * @deprecated Please use `FunctionComponentFactory`
+   */
+  type SFCFactory<P> = FunctionComponentFactory<P>;
+
+  type FunctionComponentFactory<P> = (
+    props?: Attributes & P,
+    ...children: ReactNode[]
+  ) => FunctionComponentElement<P>;
+
+  type ComponentFactory<P, T extends Component<P, ComponentState>> = (
+    props?: ClassAttributes<T> & P,
+    ...children: ReactNode[]
+  ) => CElement<P, T>;
+
+  type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<
+    P,
+    T
+  >;
+  type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
+
+  type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
+    props?: (ClassAttributes<T> & P) | null,
+    ...children: ReactNode[]
+  ) => DOMElement<P, T>;
+
+  interface HTMLFactory<T extends HTMLElement>
+    extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
+
+  interface DetailedHTMLFactory<
+    P extends HTMLAttributes<T>,
+    T extends HTMLElement
+  > extends DOMFactory<P, T> {
+    (
+      props?: (ClassAttributes<T> & P) | null,
+      ...children: ReactNode[]
+    ): DetailedReactHTMLElement<P, T>;
+  }
+
+  interface SVGFactory
+    extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
+    (
+      props?: (ClassAttributes<SVGElement> & SVGAttributes<SVGElement>) | null,
+      ...children: ReactNode[]
+    ): ReactSVGElement;
+  }
+
+  //
+  // React Nodes
+  // http://facebook.github.io/react/docs/glossary.html
+  // ----------------------------------------------------------------------
+
+  type ReactText = string | number;
+  type ReactChild = ReactElement | ReactText;
+
+  /**
+   * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.
+   */
+  interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
+  type ReactFragment = Iterable<ReactNode>;
+  type ReactNode =
+    | ReactChild
+    | ReactFragment
+    | ReactPortal
+    | boolean
+    | null
+    | undefined;
+
+  //
+  // Top Level API
+  // ----------------------------------------------------------------------
+
+  // DOM Elements
+  function createFactory<T extends HTMLElement>(
+    type: keyof ReactHTML
+  ): HTMLFactory<T>;
+  function createFactory(type: keyof ReactSVG): SVGFactory;
+  function createFactory<P extends DOMAttributes<T>, T extends Element>(
+    type: string
+  ): DOMFactory<P, T>;
+
+  // Custom components
+  function createFactory<P>(
+    type: FunctionComponent<P>
+  ): FunctionComponentFactory<P>;
+  function createFactory<P>(
+    type: ClassType<
+      P,
+      ClassicComponent<P, ComponentState>,
+      ClassicComponentClass<P>
+    >
+  ): CFactory<P, ClassicComponent<P, ComponentState>>;
+  function createFactory<
+    P,
+    T extends Component<P, ComponentState>,
+    C extends ComponentClass<P>
+  >(type: ClassType<P, T, C>): CFactory<P, T>;
+  function createFactory<P>(type: ComponentClass<P>): Factory<P>;
+
+  // DOM Elements
+  // TODO: generalize this to everything in `keyof ReactHTML`, not just "input"
+  function createElement(
+    type: "input",
+    props?:
+      | (InputHTMLAttributes<HTMLInputElement> &
+          ClassAttributes<HTMLInputElement>)
+      | null,
+    ...children: ReactNode[]
+  ): DetailedReactHTMLElement<
+    InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  >;
+  function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+    type: keyof ReactHTML,
+    props?: (ClassAttributes<T> & P) | null,
+    ...children: ReactNode[]
+  ): DetailedReactHTMLElement<P, T>;
+  function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
+    type: keyof ReactSVG,
+    props?: (ClassAttributes<T> & P) | null,
+    ...children: ReactNode[]
+  ): ReactSVGElement;
+  function createElement<P extends DOMAttributes<T>, T extends Element>(
+    type: string,
+    props?: (ClassAttributes<T> & P) | null,
+    ...children: ReactNode[]
+  ): DOMElement<P, T>;
+
+  // Custom components
+
+  function createElement<P extends {}>(
+    type: FunctionComponent<P>,
+    props?: (Attributes & P) | null,
+    ...children: ReactNode[]
+  ): FunctionComponentElement<P>;
+  function createElement<P extends {}>(
+    type: ClassType<
+      P,
+      ClassicComponent<P, ComponentState>,
+      ClassicComponentClass<P>
+    >,
+    props?: (ClassAttributes<ClassicComponent<P, ComponentState>> & P) | null,
+    ...children: ReactNode[]
+  ): CElement<P, ClassicComponent<P, ComponentState>>;
+  function createElement<
+    P extends {},
+    T extends Component<P, ComponentState>,
+    C extends ComponentClass<P>
+  >(
+    type: ClassType<P, T, C>,
+    props?: (ClassAttributes<T> & P) | null,
+    ...children: ReactNode[]
+  ): CElement<P, T>;
+  function createElement<P extends {}>(
+    type: FunctionComponent<P> | ComponentClass<P> | string,
+    props?: (Attributes & P) | null,
+    ...children: ReactNode[]
+  ): ReactElement<P>;
+
+  // DOM Elements
+  // ReactHTMLElement
+  function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+    element: DetailedReactHTMLElement<P, T>,
+    props?: P,
+    ...children: ReactNode[]
+  ): DetailedReactHTMLElement<P, T>;
+  // ReactHTMLElement, less specific
+  function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+    element: ReactHTMLElement<T>,
+    props?: P,
+    ...children: ReactNode[]
+  ): ReactHTMLElement<T>;
+  // SVGElement
+  function cloneElement<P extends SVGAttributes<T>, T extends SVGElement>(
+    element: ReactSVGElement,
+    props?: P,
+    ...children: ReactNode[]
+  ): ReactSVGElement;
+  // DOM Element (has to be the last, because type checking stops at first overload that fits)
+  function cloneElement<P extends DOMAttributes<T>, T extends Element>(
+    element: DOMElement<P, T>,
+    props?: DOMAttributes<T> & P,
+    ...children: ReactNode[]
+  ): DOMElement<P, T>;
+
+  // Custom components
+  function cloneElement<P>(
+    element: FunctionComponentElement<P>,
+    props?: Partial<P> & Attributes,
+    ...children: ReactNode[]
+  ): FunctionComponentElement<P>;
+  function cloneElement<P, T extends Component<P, ComponentState>>(
+    element: CElement<P, T>,
+    props?: Partial<P> & ClassAttributes<T>,
+    ...children: ReactNode[]
+  ): CElement<P, T>;
+  function cloneElement<P>(
+    element: ReactElement<P>,
+    props?: Partial<P> & Attributes,
+    ...children: ReactNode[]
+  ): ReactElement<P>;
+
+  // Context via RenderProps
+  interface ProviderProps<T> {
+    value: T;
+    children?: ReactNode | undefined;
+  }
+
+  interface ConsumerProps<T> {
+    children: (value: T) => ReactNode;
+  }
+
+  // TODO: similar to how Fragment is actually a symbol, the values returned from createContext,
+  // forwardRef and memo are actually objects that are treated specially by the renderer; see:
+  // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/ReactContext.js#L35-L48
+  // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/forwardRef.js#L42-L45
+  // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/memo.js#L27-L31
+  // However, we have no way of telling the JSX parser that it's a JSX element type or its props other than
+  // by pretending to be a normal component.
+  //
+  // We don't just use ComponentType or FunctionComponent types because you are not supposed to attach statics to this
+  // object, but rather to the original function.
+  interface ExoticComponent<P = {}> {
+    /**
+     * **NOTE**: Exotic components are not callable.
+     */
+    (props: P): ReactElement | null;
+    readonly $$typeof: symbol;
+  }
+
+  interface NamedExoticComponent<P = {}> extends ExoticComponent<P> {
+    displayName?: string | undefined;
+  }
+
+  interface ProviderExoticComponent<P> extends ExoticComponent<P> {
+    propTypes?: WeakValidationMap<P> | undefined;
+  }
+
+  type ContextType<C extends Context<any>> = C extends Context<infer T>
+    ? T
+    : never;
+
+  // NOTE: only the Context object itself can get a displayName
+  // https://github.com/facebook/react-devtools/blob/e0b854e4c/backend/attachRendererFiber.js#L310-L325
+  type Provider<T> = ProviderExoticComponent<ProviderProps<T>>;
+  type Consumer<T> = ExoticComponent<ConsumerProps<T>>;
+  interface Context<T> {
+    Provider: Provider<T>;
+    Consumer: Consumer<T>;
+    displayName?: string | undefined;
+  }
+  function createContext<T>(
+    // If you thought this should be optional, see
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382213106
+    defaultValue: T
+  ): Context<T>;
+
+  function isValidElement<P>(
+    object: {} | null | undefined
+  ): object is ReactElement<P>;
+
+  // Sync with `ReactChildren` until `ReactChildren` is removed.
+  const Children: {
+    map<T, C>(
+      children: C | ReadonlyArray<C>,
+      fn: (child: C, index: number) => T
+    ): C extends null | undefined
+      ? C
+      : Array<Exclude<T, boolean | null | undefined>>;
+    forEach<C>(
+      children: C | ReadonlyArray<C>,
+      fn: (child: C, index: number) => void
+    ): void;
+    count(children: any): number;
+    only<C>(children: C): C extends any[] ? never : C;
+    toArray(
+      children: ReactNode | ReactNode[]
+    ): Array<Exclude<ReactNode, boolean | null | undefined>>;
+  };
+  const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
+  const StrictMode: ExoticComponent<{ children?: ReactNode | undefined }>;
+
+  interface SuspenseProps {
+    children?: ReactNode | undefined;
+
+    /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
+    fallback?: ReactNode;
+  }
+
+  const Suspense: ExoticComponent<SuspenseProps>;
+  const version: string;
+
+  /**
+   * {@link https://reactjs.org/docs/profiler.html#onrender-callback Profiler API}
+   */
+  type ProfilerOnRenderCallback = (
+    id: string,
+    phase: "mount" | "update",
+    actualDuration: number,
+    baseDuration: number,
+    startTime: number,
+    commitTime: number,
+    interactions: Set<SchedulerInteraction>
+  ) => void;
+  interface ProfilerProps {
+    children?: ReactNode | undefined;
+    id: string;
+    onRender: ProfilerOnRenderCallback;
+  }
+
+  const Profiler: ExoticComponent<ProfilerProps>;
+
+  //
+  // Component API
+  // ----------------------------------------------------------------------
+
+  type ReactInstance = Component<any> | Element;
+
+  // Base component for plain JS classes
+  interface Component<P = {}, S = {}, SS = any>
+    extends ComponentLifecycle<P, S, SS> {}
+  class Component<P, S> {
+    // tslint won't let me format the sample code in a way that vscode likes it :(
+    /**
+     * If set, `this.context` will be set at runtime to the current value of the given Context.
+     *
+     * Usage:
+     *
+     * ```ts
+     * type MyContext = number
+     * const Ctx = React.createContext<MyContext>(0)
+     *
+     * class Foo extends React.Component {
+     *   static contextType = Ctx
+     *   context!: React.ContextType<typeof Ctx>
+     *   render () {
+     *     return <>My context's value: {this.context}</>;
+     *   }
+     * }
+     * ```
+     *
+     * @see https://reactjs.org/docs/context.html#classcontexttype
+     */
+    static contextType?: Context<any> | undefined;
+
+    /**
+     * If using the new style context, re-declare this in your class to be the
+     * `React.ContextType` of your `static contextType`.
+     * Should be used with type annotation or static contextType.
+     *
+     * ```ts
+     * static contextType = MyContext
+     * // For TS pre-3.7:
+     * context!: React.ContextType<typeof MyContext>
+     * // For TS 3.7 and above:
+     * declare context: React.ContextType<typeof MyContext>
+     * ```
+     *
+     * @see https://reactjs.org/docs/context.html
+     */
+    context: unknown;
+
+    constructor(props: Readonly<P> | P);
+    /**
+     * @deprecated
+     * @see https://reactjs.org/docs/legacy-context.html
+     */
+    constructor(props: P, context: any);
+
+    // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
+    // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
+    // Also, the ` | S` allows intellisense to not be dumbisense
+    setState<K extends keyof S>(
+      state:
+        | ((
+            prevState: Readonly<S>,
+            props: Readonly<P>
+          ) => Pick<S, K> | S | null)
+        | (Pick<S, K> | S | null),
+      callback?: () => void
+    ): void;
+
+    forceUpdate(callback?: () => void): void;
+    render(): ReactNode;
+
+    readonly props: Readonly<P>;
+    state: Readonly<S>;
+    /**
+     * @deprecated
+     * https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
+     */
+    refs: {
+      [key: string]: ReactInstance;
+    };
+  }
+
+  class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> {}
+
+  interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
+    replaceState(nextState: S, callback?: () => void): void;
+    isMounted(): boolean;
+    getInitialState?(): S;
+  }
+
+  interface ChildContextProvider<CC> {
+    getChildContext(): CC;
+  }
+
+  //
+  // Class Interfaces
+  // ----------------------------------------------------------------------
+
+  type FC<P = {}> = FunctionComponent<P>;
+
+  interface FunctionComponent<P = {}> {
+    (props: P, context?: any): ReactElement<any, any> | null;
+    propTypes?: WeakValidationMap<P> | undefined;
+    contextTypes?: ValidationMap<any> | undefined;
+    defaultProps?: Partial<P> | undefined;
+    displayName?: string | undefined;
+  }
+
+  /**
+   * @deprecated - Equivalent with `React.FC`.
+   */
+  type VFC<P = {}> = VoidFunctionComponent<P>;
+
+  /**
+   * @deprecated - Equivalent with `React.FunctionComponent`.
+   */
+  interface VoidFunctionComponent<P = {}> {
+    (props: P, context?: any): ReactElement<any, any> | null;
+    propTypes?: WeakValidationMap<P> | undefined;
+    contextTypes?: ValidationMap<any> | undefined;
+    defaultProps?: Partial<P> | undefined;
+    displayName?: string | undefined;
+  }
+
+  type ForwardedRef<T> =
+    | ((instance: T | null) => void)
+    | MutableRefObject<T | null>
+    | null;
+
+  interface ForwardRefRenderFunction<T, P = {}> {
+    (props: P, ref: ForwardedRef<T>): ReactElement | null;
+    displayName?: string | undefined;
+    // explicit rejected with `never` required due to
+    // https://github.com/microsoft/TypeScript/issues/36826
+    /**
+     * defaultProps are not supported on render functions
+     */
+    defaultProps?: never | undefined;
+    /**
+     * propTypes are not supported on render functions
+     */
+    propTypes?: never | undefined;
+  }
+
+  interface ComponentClass<P = {}, S = ComponentState>
+    extends StaticLifecycle<P, S> {
+    new (props: P, context?: any): Component<P, S>;
+    propTypes?: WeakValidationMap<P> | undefined;
+    contextType?: Context<any> | undefined;
+    contextTypes?: ValidationMap<any> | undefined;
+    childContextTypes?: ValidationMap<any> | undefined;
+    defaultProps?: Partial<P> | undefined;
+    displayName?: string | undefined;
+  }
+
+  interface ClassicComponentClass<P = {}> extends ComponentClass<P> {
+    new (props: P, context?: any): ClassicComponent<P, ComponentState>;
+    getDefaultProps?(): P;
+  }
+
+  /**
+   * We use an intersection type to infer multiple type parameters from
+   * a single argument, which is useful for many top-level API defs.
+   * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
+   */
+  type ClassType<
+    P,
+    T extends Component<P, ComponentState>,
+    C extends ComponentClass<P>
+  > = C & (new (props: P, context?: any) => T);
+
+  //
+  // Component Specs and Lifecycle
+  // ----------------------------------------------------------------------
+
+  // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
+  // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
+  // methods are present.
+  interface ComponentLifecycle<P, S, SS = any>
+    extends NewLifecycle<P, S, SS>,
+      DeprecatedLifecycle<P, S> {
+    /**
+     * Called immediately after a component is mounted. Setting state here will trigger re-rendering.
+     */
+    componentDidMount?(): void;
+    /**
+     * Called to determine whether the change in props and state should trigger a re-render.
+     *
+     * `Component` always returns true.
+     * `PureComponent` implements a shallow comparison on props and state and returns true if any
+     * props or states have changed.
+     *
+     * If false is returned, `Component#render`, `componentWillUpdate`
+     * and `componentDidUpdate` will not be called.
+     */
+    shouldComponentUpdate?(
+      nextProps: Readonly<P>,
+      nextState: Readonly<S>,
+      nextContext: any
+    ): boolean;
+    /**
+     * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
+     * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
+     */
+    componentWillUnmount?(): void;
+    /**
+     * Catches exceptions generated in descendant components. Unhandled exceptions will cause
+     * the entire component tree to unmount.
+     */
+    componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+  }
+
+  // Unfortunately, we have no way of declaring that the component constructor must implement this
+  interface StaticLifecycle<P, S> {
+    getDerivedStateFromProps?: GetDerivedStateFromProps<P, S> | undefined;
+    getDerivedStateFromError?: GetDerivedStateFromError<P, S> | undefined;
+  }
+
+  type GetDerivedStateFromProps<P, S> =
+    /**
+     * Returns an update to a component's state based on its new props and old state.
+     *
+     * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+     */
+    (nextProps: Readonly<P>, prevState: S) => Partial<S> | null;
+
+  type GetDerivedStateFromError<P, S> =
+    /**
+     * This lifecycle is invoked after an error has been thrown by a descendant component.
+     * It receives the error that was thrown as a parameter and should return a value to update state.
+     *
+     * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+     */
+    (error: any) => Partial<S> | null;
+
+  // This should be "infer SS" but can't use it yet
+  interface NewLifecycle<P, S, SS> {
+    /**
+     * Runs before React applies the result of `render` to the document, and
+     * returns an object to be given to componentDidUpdate. Useful for saving
+     * things such as scroll position before `render` causes changes to it.
+     *
+     * Note: the presence of getSnapshotBeforeUpdate prevents any of the deprecated
+     * lifecycle events from running.
+     */
+    getSnapshotBeforeUpdate?(
+      prevProps: Readonly<P>,
+      prevState: Readonly<S>
+    ): SS | null;
+    /**
+     * Called immediately after updating occurs. Not called for the initial render.
+     *
+     * The snapshot is only present if getSnapshotBeforeUpdate is present and returns non-null.
+     */
+    componentDidUpdate?(
+      prevProps: Readonly<P>,
+      prevState: Readonly<S>,
+      snapshot?: SS
+    ): void;
+  }
+
+  interface DeprecatedLifecycle<P, S> {
+    /**
+     * Called immediately before mounting occurs, and before `Component#render`.
+     * Avoid introducing any side-effects or subscriptions in this method.
+     *
+     * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+     * prevents this from being invoked.
+     *
+     * @deprecated 16.3, use componentDidMount or the constructor instead; will stop working in React 17
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+     */
+    componentWillMount?(): void;
+    /**
+     * Called immediately before mounting occurs, and before `Component#render`.
+     * Avoid introducing any side-effects or subscriptions in this method.
+     *
+     * This method will not stop working in React 17.
+     *
+     * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+     * prevents this from being invoked.
+     *
+     * @deprecated 16.3, use componentDidMount or the constructor instead
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+     */
+    UNSAFE_componentWillMount?(): void;
+    /**
+     * Called when the component may be receiving new props.
+     * React may call this even if props have not changed, so be sure to compare new and existing
+     * props if you only want to handle changes.
+     *
+     * Calling `Component#setState` generally does not trigger this method.
+     *
+     * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+     * prevents this from being invoked.
+     *
+     * @deprecated 16.3, use static getDerivedStateFromProps instead; will stop working in React 17
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+     */
+    componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+    /**
+     * Called when the component may be receiving new props.
+     * React may call this even if props have not changed, so be sure to compare new and existing
+     * props if you only want to handle changes.
+     *
+     * Calling `Component#setState` generally does not trigger this method.
+     *
+     * This method will not stop working in React 17.
+     *
+     * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+     * prevents this from being invoked.
+     *
+     * @deprecated 16.3, use static getDerivedStateFromProps instead
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+     */
+    UNSAFE_componentWillReceiveProps?(
+      nextProps: Readonly<P>,
+      nextContext: any
+    ): void;
+    /**
+     * Called immediately before rendering when new props or state is received. Not called for the initial render.
+     *
+     * Note: You cannot call `Component#setState` here.
+     *
+     * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+     * prevents this from being invoked.
+     *
+     * @deprecated 16.3, use getSnapshotBeforeUpdate instead; will stop working in React 17
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+     */
+    componentWillUpdate?(
+      nextProps: Readonly<P>,
+      nextState: Readonly<S>,
+      nextContext: any
+    ): void;
+    /**
+     * Called immediately before rendering when new props or state is received. Not called for the initial render.
+     *
+     * Note: You cannot call `Component#setState` here.
+     *
+     * This method will not stop working in React 17.
+     *
+     * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+     * prevents this from being invoked.
+     *
+     * @deprecated 16.3, use getSnapshotBeforeUpdate instead
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+     * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+     */
+    UNSAFE_componentWillUpdate?(
+      nextProps: Readonly<P>,
+      nextState: Readonly<S>,
+      nextContext: any
+    ): void;
+  }
+
+  interface Mixin<P, S> extends ComponentLifecycle<P, S> {
+    mixins?: Array<Mixin<P, S>> | undefined;
+    statics?:
+      | {
+          [key: string]: any;
+        }
+      | undefined;
+
+    displayName?: string | undefined;
+    propTypes?: ValidationMap<any> | undefined;
+    contextTypes?: ValidationMap<any> | undefined;
+    childContextTypes?: ValidationMap<any> | undefined;
+
+    getDefaultProps?(): P;
+    getInitialState?(): S;
+  }
+
+  interface ComponentSpec<P, S> extends Mixin<P, S> {
+    render(): ReactNode;
+
+    [propertyName: string]: any;
+  }
+
+  function createRef<T>(): RefObject<T>;
+
+  // will show `ForwardRef(${Component.displayName || Component.name})` in devtools by default,
+  // but can be given its own specific name
+  interface ForwardRefExoticComponent<P> extends NamedExoticComponent<P> {
+    defaultProps?: Partial<P> | undefined;
+    propTypes?: WeakValidationMap<P> | undefined;
+  }
+
+  function forwardRef<T, P = {}>(
+    render: ForwardRefRenderFunction<T, P>
+  ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+
+  /** Ensures that the props do not include ref at all */
+  type PropsWithoutRef<P> =
+    // Pick would not be sufficient for this. We'd like to avoid unnecessary mapping and need a distributive conditional to support unions.
+    // see: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
+    // https://github.com/Microsoft/TypeScript/issues/28339
+    P extends any
+      ? "ref" extends keyof P
+        ? Pick<P, Exclude<keyof P, "ref">>
+        : P
+      : P;
+  /** Ensures that the props do not include string ref, which cannot be forwarded */
+  type PropsWithRef<P> =
+    // Just "P extends { ref?: infer R }" looks sufficient, but R will infer as {} if P is {}.
+    "ref" extends keyof P
+      ? P extends { ref?: infer R | undefined }
+        ? string extends R
+          ? PropsWithoutRef<P> & { ref?: Exclude<R, string> | undefined }
+          : P
+        : P
+      : P;
+
+  type PropsWithChildren<P> = P & { children?: ReactNode | undefined };
+
+  /**
+   * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
+   * or ComponentPropsWithoutRef when refs are not supported.
+   */
+  type ComponentProps<
+    T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>
+  > = T extends JSXElementConstructor<infer P>
+    ? P
+    : T extends keyof JSX.IntrinsicElements
+    ? JSX.IntrinsicElements[T]
+    : {};
+  type ComponentPropsWithRef<T extends ElementType> = T extends new (
+    props: infer P
+  ) => Component<any, any>
+    ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
+    : PropsWithRef<ComponentProps<T>>;
+  type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<
+    ComponentProps<T>
+  >;
+
+  type ComponentRef<T extends ElementType> = T extends NamedExoticComponent<
+    ComponentPropsWithoutRef<T> & RefAttributes<infer Method>
+  >
+    ? Method
+    : ComponentPropsWithRef<T> extends RefAttributes<infer Method>
+    ? Method
+    : never;
+
+  // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
+  // but can be given its own specific name
+  type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<
+    ComponentPropsWithRef<T>
+  > & {
+    readonly type: T;
+  };
+
+  function memo<P extends object>(
+    Component: FunctionComponent<P>,
+    propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
+  ): NamedExoticComponent<P>;
+  function memo<T extends ComponentType<any>>(
+    Component: T,
+    propsAreEqual?: (
+      prevProps: Readonly<ComponentProps<T>>,
+      nextProps: Readonly<ComponentProps<T>>
+    ) => boolean
+  ): MemoExoticComponent<T>;
+
+  type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<
+    ComponentPropsWithRef<T>
+  > & {
+    readonly _result: T;
+  };
+
+  function lazy<T extends ComponentType<any>>(
+    factory: () => Promise<{ default: T }>
+  ): LazyExoticComponent<T>;
+
+  //
+  // React Hooks
+  // ----------------------------------------------------------------------
+
+  // based on the code in https://github.com/facebook/react/pull/13968
+
+  // Unlike the class component setState, the updates are not allowed to be partial
+  type SetStateAction<S> = S | ((prevState: S) => S);
+  // this technically does accept a second argument, but it's already under a deprecation warning
+  // and it's not even released so probably better to not define it.
+  type Dispatch<A> = (value: A) => void;
+  // Since action _can_ be undefined, dispatch may be called without any parameters.
+  type DispatchWithoutAction = () => void;
+  // Unlike redux, the actions _can_ be anything
+  type Reducer<S, A> = (prevState: S, action: A) => S;
+  // If useReducer accepts a reducer without action, dispatch may be called without any parameters.
+  type ReducerWithoutAction<S> = (prevState: S) => S;
+  // types used to try and prevent the compiler from reducing S
+  // to a supertype common with the second argument to useReducer()
+  type ReducerState<R extends Reducer<any, any>> = R extends Reducer<
+    infer S,
+    any
+  >
+    ? S
+    : never;
+  type ReducerAction<R extends Reducer<any, any>> = R extends Reducer<
+    any,
+    infer A
+  >
+    ? A
+    : never;
+  // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
+  type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> =
+    R extends ReducerWithoutAction<infer S> ? S : never;
+  type DependencyList = ReadonlyArray<unknown>;
+
+  // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
+  type EffectCallback = () => void | Destructor;
+
+  interface MutableRefObject<T> {
+    current: T;
+  }
+
+  // This will technically work if you give a Consumer<T> or Provider<T> but it's deprecated and warns
+  /**
+   * Accepts a context object (the value returned from `React.createContext`) and returns the current
+   * context value, as given by the nearest context provider for the given context.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usecontext
+   */
+  function useContext<T>(
+    context: Context<T> /*, (not public API) observedBits?: number|boolean */
+  ): T;
+  /**
+   * Returns a stateful value, and a function to update it.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usestate
+   */
+  function useState<S>(
+    initialState: S | (() => S)
+  ): [S, Dispatch<SetStateAction<S>>];
+  // convenience overload when first argument is omitted
+  /**
+   * Returns a stateful value, and a function to update it.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usestate
+   */
+  function useState<S = undefined>(): [
+    S | undefined,
+    Dispatch<SetStateAction<S | undefined>>
+  ];
+  /**
+   * An alternative to `useState`.
+   *
+   * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+   * multiple sub-values. It also lets you optimize performance for components that trigger deep
+   * updates because you can pass `dispatch` down instead of callbacks.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+   */
+  // overload where dispatch could accept 0 arguments.
+  function useReducer<R extends ReducerWithoutAction<any>, I>(
+    reducer: R,
+    initializerArg: I,
+    initializer: (arg: I) => ReducerStateWithoutAction<R>
+  ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
+  /**
+   * An alternative to `useState`.
+   *
+   * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+   * multiple sub-values. It also lets you optimize performance for components that trigger deep
+   * updates because you can pass `dispatch` down instead of callbacks.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+   */
+  // overload where dispatch could accept 0 arguments.
+  function useReducer<R extends ReducerWithoutAction<any>>(
+    reducer: R,
+    initializerArg: ReducerStateWithoutAction<R>,
+    initializer?: undefined
+  ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
+  /**
+   * An alternative to `useState`.
+   *
+   * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+   * multiple sub-values. It also lets you optimize performance for components that trigger deep
+   * updates because you can pass `dispatch` down instead of callbacks.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+   */
+  // overload where "I" may be a subset of ReducerState<R>; used to provide autocompletion.
+  // If "I" matches ReducerState<R> exactly then the last overload will allow initializer to be omitted.
+  // the last overload effectively behaves as if the identity function (x => x) is the initializer.
+  function useReducer<R extends Reducer<any, any>, I>(
+    reducer: R,
+    initializerArg: I & ReducerState<R>,
+    initializer: (arg: I & ReducerState<R>) => ReducerState<R>
+  ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+  /**
+   * An alternative to `useState`.
+   *
+   * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+   * multiple sub-values. It also lets you optimize performance for components that trigger deep
+   * updates because you can pass `dispatch` down instead of callbacks.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+   */
+  // overload for free "I"; all goes as long as initializer converts it into "ReducerState<R>".
+  function useReducer<R extends Reducer<any, any>, I>(
+    reducer: R,
+    initializerArg: I,
+    initializer: (arg: I) => ReducerState<R>
+  ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+  /**
+   * An alternative to `useState`.
+   *
+   * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+   * multiple sub-values. It also lets you optimize performance for components that trigger deep
+   * updates because you can pass `dispatch` down instead of callbacks.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+   */
+
+  // I'm not sure if I keep this 2-ary or if I make it (2,3)-ary; it's currently (2,3)-ary.
+  // The Flow types do have an overload for 3-ary invocation with undefined initializer.
+
+  // NOTE: without the ReducerState indirection, TypeScript would reduce S to be the most common
+  // supertype between the reducer's return type and the initialState (or the initializer's return type),
+  // which would prevent autocompletion from ever working.
+
+  // TODO: double-check if this weird overload logic is necessary. It is possible it's either a bug
+  // in older versions, or a regression in newer versions of the typescript completion service.
+  function useReducer<R extends Reducer<any, any>>(
+    reducer: R,
+    initialState: ReducerState<R>,
+    initializer?: undefined
+  ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+  /**
+   * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+   * (`initialValue`). The returned object will persist for the full lifetime of the component.
+   *
+   * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+   * value around similar to how you’d use instance fields in classes.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#useref
+   */
+  function useRef<T>(initialValue: T): MutableRefObject<T>;
+  // convenience overload for refs given as a ref prop as they typically start with a null value
+  /**
+   * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+   * (`initialValue`). The returned object will persist for the full lifetime of the component.
+   *
+   * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+   * value around similar to how you’d use instance fields in classes.
+   *
+   * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
+   * of the generic argument.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#useref
+   */
+  function useRef<T>(initialValue: T | null): RefObject<T>;
+  // convenience overload for potentially undefined initialValue / call with 0 arguments
+  // has a default to stop it from defaulting to {} instead
+  /**
+   * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+   * (`initialValue`). The returned object will persist for the full lifetime of the component.
+   *
+   * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+   * value around similar to how you’d use instance fields in classes.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#useref
+   */
+  function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+  /**
+   * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
+   * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
+   * `useLayoutEffect` will be flushed synchronously, before the browser has a chance to paint.
+   *
+   * Prefer the standard `useEffect` when possible to avoid blocking visual updates.
+   *
+   * If you’re migrating code from a class component, `useLayoutEffect` fires in the same phase as
+   * `componentDidMount` and `componentDidUpdate`.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#uselayouteffect
+   */
+  function useLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
+  /**
+   * Accepts a function that contains imperative, possibly effectful code.
+   *
+   * @param effect Imperative function that can return a cleanup function
+   * @param deps If present, effect will only activate if the values in the list change.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#useeffect
+   */
+  function useEffect(effect: EffectCallback, deps?: DependencyList): void;
+  // NOTE: this does not accept strings, but this will have to be fixed by removing strings from type Ref<T>
+  /**
+   * `useImperativeHandle` customizes the instance value that is exposed to parent components when using
+   * `ref`. As always, imperative code using refs should be avoided in most cases.
+   *
+   * `useImperativeHandle` should be used with `React.forwardRef`.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#useimperativehandle
+   */
+  function useImperativeHandle<T, R extends T>(
+    ref: Ref<T> | undefined,
+    init: () => R,
+    deps?: DependencyList
+  ): void;
+  // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
+  // useCallback(X) is identical to just using X, useMemo(() => Y) is identical to just using Y.
+  /**
+   * `useCallback` will return a memoized version of the callback that only changes if one of the `inputs`
+   * has changed.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usecallback
+   */
+  // A specific function type would not trigger implicit any.
+  // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52873#issuecomment-845806435 for a comparison between `Function` and more specific types.
+  // tslint:disable-next-line ban-types
+  function useCallback<T extends Function>(
+    callback: T,
+    deps: DependencyList
+  ): T;
+  /**
+   * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usememo
+   */
+  // allow undefined, but don't make it optional as that is very likely a mistake
+  function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+  /**
+   * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
+   *
+   * NOTE: We don’t recommend adding debug values to every custom hook.
+   * It’s most valuable for custom hooks that are part of shared libraries.
+   *
+   * @version 16.8.0
+   * @see https://reactjs.org/docs/hooks-reference.html#usedebugvalue
+   */
+  // the name of the custom hook is itself derived from the function name at runtime:
+  // it's just the function name without the "use" prefix.
+  function useDebugValue<T>(value: T, format?: (value: T) => any): void;
+
+  // must be synchronous
+  export type TransitionFunction = () => VoidOrUndefinedOnly;
+  // strange definition to allow vscode to show documentation on the invocation
+  export interface TransitionStartFunction {
+    /**
+     * State updates caused inside the callback are allowed to be deferred.
+     *
+     * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
+     *
+     * @param callback A _synchronous_ function which causes state updates that can be deferred.
+     */
+    (callback: TransitionFunction): void;
+  }
+
+  /**
+   * Returns a deferred version of the value that may “lag behind” it for at most `timeoutMs`.
+   *
+   * This is commonly used to keep the interface responsive when you have something that renders immediately
+   * based on user input and something that needs to wait for a data fetch.
+   *
+   * A good example of this is a text input.
+   *
+   * @param value The value that is going to be deferred
+   *
+   * @see https://reactjs.org/docs/concurrent-mode-reference.html#usedeferredvalue
+   */
+  export function useDeferredValue<T>(value: T): T;
+
+  /**
+   * Allows components to avoid undesirable loading states by waiting for content to load
+   * before transitioning to the next screen. It also allows components to defer slower,
+   * data fetching updates until subsequent renders so that more crucial updates can be
+   * rendered immediately.
+   *
+   * The `useTransition` hook returns two values in an array.
+   *
+   * The first is a boolean, React’s way of informing us whether we’re waiting for the transition to finish.
+   * The second is a function that takes a callback. We can use it to tell React which state we want to defer.
+   *
+   * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
+   *
+   * @param config An optional object with `timeoutMs`
+   *
+   * @see https://reactjs.org/docs/concurrent-mode-reference.html#usetransition
+   */
+  export function useTransition(): [boolean, TransitionStartFunction];
+
+  /**
+   * Similar to `useTransition` but allows uses where hooks are not available.
+   *
+   * @param callback A _synchronous_ function which causes state updates that can be deferred.
+   */
+  export function startTransition(scope: TransitionFunction): void;
+
+  export function useId(): string;
+
+  /**
+   * @param effect Imperative function that can return a cleanup function
+   * @param deps If present, effect will only activate if the values in the list change.
+   *
+   * @see https://github.com/facebook/react/pull/21913
+   */
+  export function useInsertionEffect(
+    effect: EffectCallback,
+    deps?: DependencyList
+  ): void;
+
+  /**
+   * @param subscribe
+   * @param getSnapshot
+   *
+   * @see https://github.com/reactwg/react-18/discussions/86
+   */
+  // keep in sync with `useSyncExternalStore` from `use-sync-external-store`
+  export function useSyncExternalStore<Snapshot>(
+    subscribe: (onStoreChange: () => void) => () => void,
+    getSnapshot: () => Snapshot,
+    getServerSnapshot?: () => Snapshot
+  ): Snapshot;
+
+  //
+  // Event System
+  // ----------------------------------------------------------------------
+  // TODO: change any to unknown when moving to TS v3
+  interface BaseSyntheticEvent<E = object, C = any, T = any> {
+    nativeEvent: E;
+    currentTarget: C;
+    target: T;
+    bubbles: boolean;
+    cancelable: boolean;
+    defaultPrevented: boolean;
+    eventPhase: number;
+    isTrusted: boolean;
+    preventDefault(): void;
+    isDefaultPrevented(): boolean;
+    stopPropagation(): void;
+    isPropagationStopped(): boolean;
+    persist(): void;
+    timeStamp: number;
+    type: string;
+  }
+
+  /**
+   * currentTarget - a reference to the element on which the event listener is registered.
+   *
+   * target - a reference to the element from which the event was originally dispatched.
+   * This might be a child element to the element on which the event listener is registered.
+   * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682
+   */
+  interface SyntheticEvent<T = Element, E = Event>
+    extends BaseSyntheticEvent<E, EventTarget & T, EventTarget> {}
+
+  interface ClipboardEvent<T = Element>
+    extends SyntheticEvent<T, NativeClipboardEvent> {
+    clipboardData: DataTransfer;
+  }
+
+  interface CompositionEvent<T = Element>
+    extends SyntheticEvent<T, NativeCompositionEvent> {
+    data: string;
+  }
+
+  interface DragEvent<T = Element> extends MouseEvent<T, NativeDragEvent> {
+    dataTransfer: DataTransfer;
+  }
+
+  interface PointerEvent<T = Element>
+    extends MouseEvent<T, NativePointerEvent> {
+    pointerId: number;
+    pressure: number;
+    tangentialPressure: number;
+    tiltX: number;
+    tiltY: number;
+    twist: number;
+    width: number;
+    height: number;
+    pointerType: "mouse" | "pen" | "touch";
+    isPrimary: boolean;
+  }
+
+  interface FocusEvent<Target = Element, RelatedTarget = Element>
+    extends SyntheticEvent<Target, NativeFocusEvent> {
+    relatedTarget: (EventTarget & RelatedTarget) | null;
+    target: EventTarget & Target;
+  }
+
+  interface FormEvent<T = Element> extends SyntheticEvent<T> {}
+
+  interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
+    target: EventTarget & T;
+  }
+
+  interface ChangeEvent<T = Element> extends SyntheticEvent<T> {
+    target: EventTarget & T;
+  }
+
+  interface KeyboardEvent<T = Element> extends UIEvent<T, NativeKeyboardEvent> {
+    altKey: boolean;
+    /** @deprecated */
+    charCode: number;
+    ctrlKey: boolean;
+    code: string;
+    /**
+     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+     */
+    getModifierState(key: string): boolean;
+    /**
+     * See the [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#named-key-attribute-values). for possible values
+     */
+    key: string;
+    /** @deprecated */
+    keyCode: number;
+    locale: string;
+    location: number;
+    metaKey: boolean;
+    repeat: boolean;
+    shiftKey: boolean;
+    /** @deprecated */
+    which: number;
+  }
+
+  interface MouseEvent<T = Element, E = NativeMouseEvent>
+    extends UIEvent<T, E> {
+    altKey: boolean;
+    button: number;
+    buttons: number;
+    clientX: number;
+    clientY: number;
+    ctrlKey: boolean;
+    /**
+     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+     */
+    getModifierState(key: string): boolean;
+    metaKey: boolean;
+    movementX: number;
+    movementY: number;
+    pageX: number;
+    pageY: number;
+    relatedTarget: EventTarget | null;
+    screenX: number;
+    screenY: number;
+    shiftKey: boolean;
+  }
+
+  interface TouchEvent<T = Element> extends UIEvent<T, NativeTouchEvent> {
+    altKey: boolean;
+    changedTouches: TouchList;
+    ctrlKey: boolean;
+    /**
+     * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+     */
+    getModifierState(key: string): boolean;
+    metaKey: boolean;
+    shiftKey: boolean;
+    targetTouches: TouchList;
+    touches: TouchList;
+  }
+
+  interface UIEvent<T = Element, E = NativeUIEvent>
+    extends SyntheticEvent<T, E> {
+    detail: number;
+    view: AbstractView;
+  }
+
+  interface WheelEvent<T = Element> extends MouseEvent<T, NativeWheelEvent> {
+    deltaMode: number;
+    deltaX: number;
+    deltaY: number;
+    deltaZ: number;
+  }
+
+  interface AnimationEvent<T = Element>
+    extends SyntheticEvent<T, NativeAnimationEvent> {
+    animationName: string;
+    elapsedTime: number;
+    pseudoElement: string;
+  }
+
+  interface TransitionEvent<T = Element>
+    extends SyntheticEvent<T, NativeTransitionEvent> {
+    elapsedTime: number;
+    propertyName: string;
+    pseudoElement: string;
+  }
+
+  //
+  // Event Handler Types
+  // ----------------------------------------------------------------------
+
+  type EventHandler<E extends SyntheticEvent<any>> = {
+    bivarianceHack(event: E): void;
+  }["bivarianceHack"];
+
+  type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
+
+  type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent<T>>;
+  type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
+  type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
+  type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
+  type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
+  type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+  type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
+  type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
+  type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
+  type PointerEventHandler<T = Element> = EventHandler<PointerEvent<T>>;
+  type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
+  type WheelEventHandler<T = Element> = EventHandler<WheelEvent<T>>;
+  type AnimationEventHandler<T = Element> = EventHandler<AnimationEvent<T>>;
+  type TransitionEventHandler<T = Element> = EventHandler<TransitionEvent<T>>;
+
+  //
+  // Props / DOM Attributes
+  // ----------------------------------------------------------------------
+
+  interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {}
+
+  type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = ClassAttributes<T> &
+    E;
+
+  interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {}
+
+  interface DOMAttributes<T> {
+    children?: ReactNode | undefined;
+    dangerouslySetInnerHTML?:
+      | {
+          __html: string;
+        }
+      | undefined;
+
+    // Clipboard Events
+    onCopy?: ClipboardEventHandler<T> | undefined;
+    onCopyCapture?: ClipboardEventHandler<T> | undefined;
+    onCut?: ClipboardEventHandler<T> | undefined;
+    onCutCapture?: ClipboardEventHandler<T> | undefined;
+    onPaste?: ClipboardEventHandler<T> | undefined;
+    onPasteCapture?: ClipboardEventHandler<T> | undefined;
+
+    // Composition Events
+    onCompositionEnd?: CompositionEventHandler<T> | undefined;
+    onCompositionEndCapture?: CompositionEventHandler<T> | undefined;
+    onCompositionStart?: CompositionEventHandler<T> | undefined;
+    onCompositionStartCapture?: CompositionEventHandler<T> | undefined;
+    onCompositionUpdate?: CompositionEventHandler<T> | undefined;
+    onCompositionUpdateCapture?: CompositionEventHandler<T> | undefined;
+
+    // Focus Events
+    onFocus?: FocusEventHandler<T> | undefined;
+    onFocusCapture?: FocusEventHandler<T> | undefined;
+    onBlur?: FocusEventHandler<T> | undefined;
+    onBlurCapture?: FocusEventHandler<T> | undefined;
+
+    // Form Events
+    onChange?: FormEventHandler<T> | undefined;
+    onChangeCapture?: FormEventHandler<T> | undefined;
+    onBeforeInput?: FormEventHandler<T> | undefined;
+    onBeforeInputCapture?: FormEventHandler<T> | undefined;
+    onInput?: FormEventHandler<T> | undefined;
+    onInputCapture?: FormEventHandler<T> | undefined;
+    onReset?: FormEventHandler<T> | undefined;
+    onResetCapture?: FormEventHandler<T> | undefined;
+    onSubmit?: FormEventHandler<T> | undefined;
+    onSubmitCapture?: FormEventHandler<T> | undefined;
+    onInvalid?: FormEventHandler<T> | undefined;
+    onInvalidCapture?: FormEventHandler<T> | undefined;
+
+    // Image Events
+    onLoad?: ReactEventHandler<T> | undefined;
+    onLoadCapture?: ReactEventHandler<T> | undefined;
+    onError?: ReactEventHandler<T> | undefined; // also a Media Event
+    onErrorCapture?: ReactEventHandler<T> | undefined; // also a Media Event
+
+    // Keyboard Events
+    onKeyDown?: KeyboardEventHandler<T> | undefined;
+    onKeyDownCapture?: KeyboardEventHandler<T> | undefined;
+    /** @deprecated */
+    onKeyPress?: KeyboardEventHandler<T> | undefined;
+    /** @deprecated */
+    onKeyPressCapture?: KeyboardEventHandler<T> | undefined;
+    onKeyUp?: KeyboardEventHandler<T> | undefined;
+    onKeyUpCapture?: KeyboardEventHandler<T> | undefined;
+
+    // Media Events
+    onAbort?: ReactEventHandler<T> | undefined;
+    onAbortCapture?: ReactEventHandler<T> | undefined;
+    onCanPlay?: ReactEventHandler<T> | undefined;
+    onCanPlayCapture?: ReactEventHandler<T> | undefined;
+    onCanPlayThrough?: ReactEventHandler<T> | undefined;
+    onCanPlayThroughCapture?: ReactEventHandler<T> | undefined;
+    onDurationChange?: ReactEventHandler<T> | undefined;
+    onDurationChangeCapture?: ReactEventHandler<T> | undefined;
+    onEmptied?: ReactEventHandler<T> | undefined;
+    onEmptiedCapture?: ReactEventHandler<T> | undefined;
+    onEncrypted?: ReactEventHandler<T> | undefined;
+    onEncryptedCapture?: ReactEventHandler<T> | undefined;
+    onEnded?: ReactEventHandler<T> | undefined;
+    onEndedCapture?: ReactEventHandler<T> | undefined;
+    onLoadedData?: ReactEventHandler<T> | undefined;
+    onLoadedDataCapture?: ReactEventHandler<T> | undefined;
+    onLoadedMetadata?: ReactEventHandler<T> | undefined;
+    onLoadedMetadataCapture?: ReactEventHandler<T> | undefined;
+    onLoadStart?: ReactEventHandler<T> | undefined;
+    onLoadStartCapture?: ReactEventHandler<T> | undefined;
+    onPause?: ReactEventHandler<T> | undefined;
+    onPauseCapture?: ReactEventHandler<T> | undefined;
+    onPlay?: ReactEventHandler<T> | undefined;
+    onPlayCapture?: ReactEventHandler<T> | undefined;
+    onPlaying?: ReactEventHandler<T> | undefined;
+    onPlayingCapture?: ReactEventHandler<T> | undefined;
+    onProgress?: ReactEventHandler<T> | undefined;
+    onProgressCapture?: ReactEventHandler<T> | undefined;
+    onRateChange?: ReactEventHandler<T> | undefined;
+    onRateChangeCapture?: ReactEventHandler<T> | undefined;
+    onSeeked?: ReactEventHandler<T> | undefined;
+    onSeekedCapture?: ReactEventHandler<T> | undefined;
+    onSeeking?: ReactEventHandler<T> | undefined;
+    onSeekingCapture?: ReactEventHandler<T> | undefined;
+    onStalled?: ReactEventHandler<T> | undefined;
+    onStalledCapture?: ReactEventHandler<T> | undefined;
+    onSuspend?: ReactEventHandler<T> | undefined;
+    onSuspendCapture?: ReactEventHandler<T> | undefined;
+    onTimeUpdate?: ReactEventHandler<T> | undefined;
+    onTimeUpdateCapture?: ReactEventHandler<T> | undefined;
+    onVolumeChange?: ReactEventHandler<T> | undefined;
+    onVolumeChangeCapture?: ReactEventHandler<T> | undefined;
+    onWaiting?: ReactEventHandler<T> | undefined;
+    onWaitingCapture?: ReactEventHandler<T> | undefined;
+
+    // MouseEvents
+    onAuxClick?: MouseEventHandler<T> | undefined;
+    onAuxClickCapture?: MouseEventHandler<T> | undefined;
+    onClick?: MouseEventHandler<T> | undefined;
+    onClickCapture?: MouseEventHandler<T> | undefined;
+    onContextMenu?: MouseEventHandler<T> | undefined;
+    onContextMenuCapture?: MouseEventHandler<T> | undefined;
+    onDoubleClick?: MouseEventHandler<T> | undefined;
+    onDoubleClickCapture?: MouseEventHandler<T> | undefined;
+    onDrag?: DragEventHandler<T> | undefined;
+    onDragCapture?: DragEventHandler<T> | undefined;
+    onDragEnd?: DragEventHandler<T> | undefined;
+    onDragEndCapture?: DragEventHandler<T> | undefined;
+    onDragEnter?: DragEventHandler<T> | undefined;
+    onDragEnterCapture?: DragEventHandler<T> | undefined;
+    onDragExit?: DragEventHandler<T> | undefined;
+    onDragExitCapture?: DragEventHandler<T> | undefined;
+    onDragLeave?: DragEventHandler<T> | undefined;
+    onDragLeaveCapture?: DragEventHandler<T> | undefined;
+    onDragOver?: DragEventHandler<T> | undefined;
+    onDragOverCapture?: DragEventHandler<T> | undefined;
+    onDragStart?: DragEventHandler<T> | undefined;
+    onDragStartCapture?: DragEventHandler<T> | undefined;
+    onDrop?: DragEventHandler<T> | undefined;
+    onDropCapture?: DragEventHandler<T> | undefined;
+    onMouseDown?: MouseEventHandler<T> | undefined;
+    onMouseDownCapture?: MouseEventHandler<T> | undefined;
+    onMouseEnter?: MouseEventHandler<T> | undefined;
+    onMouseLeave?: MouseEventHandler<T> | undefined;
+    onMouseMove?: MouseEventHandler<T> | undefined;
+    onMouseMoveCapture?: MouseEventHandler<T> | undefined;
+    onMouseOut?: MouseEventHandler<T> | undefined;
+    onMouseOutCapture?: MouseEventHandler<T> | undefined;
+    onMouseOver?: MouseEventHandler<T> | undefined;
+    onMouseOverCapture?: MouseEventHandler<T> | undefined;
+    onMouseUp?: MouseEventHandler<T> | undefined;
+    onMouseUpCapture?: MouseEventHandler<T> | undefined;
+
+    // Selection Events
+    onSelect?: ReactEventHandler<T> | undefined;
+    onSelectCapture?: ReactEventHandler<T> | undefined;
+
+    // Touch Events
+    onTouchCancel?: TouchEventHandler<T> | undefined;
+    onTouchCancelCapture?: TouchEventHandler<T> | undefined;
+    onTouchEnd?: TouchEventHandler<T> | undefined;
+    onTouchEndCapture?: TouchEventHandler<T> | undefined;
+    onTouchMove?: TouchEventHandler<T> | undefined;
+    onTouchMoveCapture?: TouchEventHandler<T> | undefined;
+    onTouchStart?: TouchEventHandler<T> | undefined;
+    onTouchStartCapture?: TouchEventHandler<T> | undefined;
+
+    // Pointer Events
+    onPointerDown?: PointerEventHandler<T> | undefined;
+    onPointerDownCapture?: PointerEventHandler<T> | undefined;
+    onPointerMove?: PointerEventHandler<T> | undefined;
+    onPointerMoveCapture?: PointerEventHandler<T> | undefined;
+    onPointerUp?: PointerEventHandler<T> | undefined;
+    onPointerUpCapture?: PointerEventHandler<T> | undefined;
+    onPointerCancel?: PointerEventHandler<T> | undefined;
+    onPointerCancelCapture?: PointerEventHandler<T> | undefined;
+    onPointerEnter?: PointerEventHandler<T> | undefined;
+    onPointerEnterCapture?: PointerEventHandler<T> | undefined;
+    onPointerLeave?: PointerEventHandler<T> | undefined;
+    onPointerLeaveCapture?: PointerEventHandler<T> | undefined;
+    onPointerOver?: PointerEventHandler<T> | undefined;
+    onPointerOverCapture?: PointerEventHandler<T> | undefined;
+    onPointerOut?: PointerEventHandler<T> | undefined;
+    onPointerOutCapture?: PointerEventHandler<T> | undefined;
+    onGotPointerCapture?: PointerEventHandler<T> | undefined;
+    onGotPointerCaptureCapture?: PointerEventHandler<T> | undefined;
+    onLostPointerCapture?: PointerEventHandler<T> | undefined;
+    onLostPointerCaptureCapture?: PointerEventHandler<T> | undefined;
+
+    // UI Events
+    onScroll?: UIEventHandler<T> | undefined;
+    onScrollCapture?: UIEventHandler<T> | undefined;
+
+    // Wheel Events
+    onWheel?: WheelEventHandler<T> | undefined;
+    onWheelCapture?: WheelEventHandler<T> | undefined;
+
+    // Animation Events
+    onAnimationStart?: AnimationEventHandler<T> | undefined;
+    onAnimationStartCapture?: AnimationEventHandler<T> | undefined;
+    onAnimationEnd?: AnimationEventHandler<T> | undefined;
+    onAnimationEndCapture?: AnimationEventHandler<T> | undefined;
+    onAnimationIteration?: AnimationEventHandler<T> | undefined;
+    onAnimationIterationCapture?: AnimationEventHandler<T> | undefined;
+
+    // Transition Events
+    onTransitionEnd?: TransitionEventHandler<T> | undefined;
+    onTransitionEndCapture?: TransitionEventHandler<T> | undefined;
+  }
+
+  export interface CSSProperties extends CSS.Properties<string | number> {
+    /**
+     * The index signature was removed to enable closed typing for style
+     * using CSSType. You're able to use type assertion or module augmentation
+     * to add properties or an index signature of your own.
+     *
+     * For examples and more information, visit:
+     * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+     */
+  }
+
+  // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
+  interface AriaAttributes {
+    /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
+    "aria-activedescendant"?: string | undefined;
+    /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
+    "aria-atomic"?: Booleanish | undefined;
+    /**
+     * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
+     * presented if they are made.
+     */
+    "aria-autocomplete"?: "none" | "inline" | "list" | "both" | undefined;
+    /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
+    "aria-busy"?: Booleanish | undefined;
+    /**
+     * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+     * @see aria-pressed @see aria-selected.
+     */
+    "aria-checked"?: boolean | "false" | "mixed" | "true" | undefined;
+    /**
+     * Defines the total number of columns in a table, grid, or treegrid.
+     * @see aria-colindex.
+     */
+    "aria-colcount"?: number | undefined;
+    /**
+     * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+     * @see aria-colcount @see aria-colspan.
+     */
+    "aria-colindex"?: number | undefined;
+    /**
+     * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+     * @see aria-colindex @see aria-rowspan.
+     */
+    "aria-colspan"?: number | undefined;
+    /**
+     * Identifies the element (or elements) whose contents or presence are controlled by the current element.
+     * @see aria-owns.
+     */
+    "aria-controls"?: string | undefined;
+    /** Indicates the element that represents the current item within a container or set of related elements. */
+    "aria-current"?:
+      | boolean
+      | "false"
+      | "true"
+      | "page"
+      | "step"
+      | "location"
+      | "date"
+      | "time"
+      | undefined;
+    /**
+     * Identifies the element (or elements) that describes the object.
+     * @see aria-labelledby
+     */
+    "aria-describedby"?: string | undefined;
+    /**
+     * Identifies the element that provides a detailed, extended description for the object.
+     * @see aria-describedby.
+     */
+    "aria-details"?: string | undefined;
+    /**
+     * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+     * @see aria-hidden @see aria-readonly.
+     */
+    "aria-disabled"?: Booleanish | undefined;
+    /**
+     * Indicates what functions can be performed when a dragged object is released on the drop target.
+     * @deprecated in ARIA 1.1
+     */
+    "aria-dropeffect"?:
+      | "none"
+      | "copy"
+      | "execute"
+      | "link"
+      | "move"
+      | "popup"
+      | undefined;
+    /**
+     * Identifies the element that provides an error message for the object.
+     * @see aria-invalid @see aria-describedby.
+     */
+    "aria-errormessage"?: string | undefined;
+    /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
+    "aria-expanded"?: Booleanish | undefined;
+    /**
+     * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
+     * allows assistive technology to override the general default of reading in document source order.
+     */
+    "aria-flowto"?: string | undefined;
+    /**
+     * Indicates an element's "grabbed" state in a drag-and-drop operation.
+     * @deprecated in ARIA 1.1
+     */
+    "aria-grabbed"?: Booleanish | undefined;
+    /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
+    "aria-haspopup"?:
+      | boolean
+      | "false"
+      | "true"
+      | "menu"
+      | "listbox"
+      | "tree"
+      | "grid"
+      | "dialog"
+      | undefined;
+    /**
+     * Indicates whether the element is exposed to an accessibility API.
+     * @see aria-disabled.
+     */
+    "aria-hidden"?: Booleanish | undefined;
+    /**
+     * Indicates the entered value does not conform to the format expected by the application.
+     * @see aria-errormessage.
+     */
+    "aria-invalid"?:
+      | boolean
+      | "false"
+      | "true"
+      | "grammar"
+      | "spelling"
+      | undefined;
+    /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
+    "aria-keyshortcuts"?: string | undefined;
+    /**
+     * Defines a string value that labels the current element.
+     * @see aria-labelledby.
+     */
+    "aria-label"?: string | undefined;
+    /**
+     * Identifies the element (or elements) that labels the current element.
+     * @see aria-describedby.
+     */
+    "aria-labelledby"?: string | undefined;
+    /** Defines the hierarchical level of an element within a structure. */
+    "aria-level"?: number | undefined;
+    /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
+    "aria-live"?: "off" | "assertive" | "polite" | undefined;
+    /** Indicates whether an element is modal when displayed. */
+    "aria-modal"?: Booleanish | undefined;
+    /** Indicates whether a text box accepts multiple lines of input or only a single line. */
+    "aria-multiline"?: Booleanish | undefined;
+    /** Indicates that the user may select more than one item from the current selectable descendants. */
+    "aria-multiselectable"?: Booleanish | undefined;
+    /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
+    "aria-orientation"?: "horizontal" | "vertical" | undefined;
+    /**
+     * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
+     * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+     * @see aria-controls.
+     */
+    "aria-owns"?: string | undefined;
+    /**
+     * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
+     * A hint could be a sample value or a brief description of the expected format.
+     */
+    "aria-placeholder"?: string | undefined;
+    /**
+     * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * @see aria-setsize.
+     */
+    "aria-posinset"?: number | undefined;
+    /**
+     * Indicates the current "pressed" state of toggle buttons.
+     * @see aria-checked @see aria-selected.
+     */
+    "aria-pressed"?: boolean | "false" | "mixed" | "true" | undefined;
+    /**
+     * Indicates that the element is not editable, but is otherwise operable.
+     * @see aria-disabled.
+     */
+    "aria-readonly"?: Booleanish | undefined;
+    /**
+     * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+     * @see aria-atomic.
+     */
+    "aria-relevant"?:
+      | "additions"
+      | "additions removals"
+      | "additions text"
+      | "all"
+      | "removals"
+      | "removals additions"
+      | "removals text"
+      | "text"
+      | "text additions"
+      | "text removals"
+      | undefined;
+    /** Indicates that user input is required on the element before a form may be submitted. */
+    "aria-required"?: Booleanish | undefined;
+    /** Defines a human-readable, author-localized description for the role of an element. */
+    "aria-roledescription"?: string | undefined;
+    /**
+     * Defines the total number of rows in a table, grid, or treegrid.
+     * @see aria-rowindex.
+     */
+    "aria-rowcount"?: number | undefined;
+    /**
+     * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+     * @see aria-rowcount @see aria-rowspan.
+     */
+    "aria-rowindex"?: number | undefined;
+    /**
+     * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+     * @see aria-rowindex @see aria-colspan.
+     */
+    "aria-rowspan"?: number | undefined;
+    /**
+     * Indicates the current "selected" state of various widgets.
+     * @see aria-checked @see aria-pressed.
+     */
+    "aria-selected"?: Booleanish | undefined;
+    /**
+     * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+     * @see aria-posinset.
+     */
+    "aria-setsize"?: number | undefined;
+    /** Indicates if items in a table or grid are sorted in ascending or descending order. */
+    "aria-sort"?: "none" | "ascending" | "descending" | "other" | undefined;
+    /** Defines the maximum allowed value for a range widget. */
+    "aria-valuemax"?: number | undefined;
+    /** Defines the minimum allowed value for a range widget. */
+    "aria-valuemin"?: number | undefined;
+    /**
+     * Defines the current value for a range widget.
+     * @see aria-valuetext.
+     */
+    "aria-valuenow"?: number | undefined;
+    /** Defines the human readable text alternative of aria-valuenow for a range widget. */
+    "aria-valuetext"?: string | undefined;
+  }
+
+  // All the WAI-ARIA 1.1 role attribute values from https://www.w3.org/TR/wai-aria-1.1/#role_definitions
+  type AriaRole =
+    | "alert"
+    | "alertdialog"
+    | "application"
+    | "article"
+    | "banner"
+    | "button"
+    | "cell"
+    | "checkbox"
+    | "columnheader"
+    | "combobox"
+    | "complementary"
+    | "contentinfo"
+    | "definition"
+    | "dialog"
+    | "directory"
+    | "document"
+    | "feed"
+    | "figure"
+    | "form"
+    | "grid"
+    | "gridcell"
+    | "group"
+    | "heading"
+    | "img"
+    | "link"
+    | "list"
+    | "listbox"
+    | "listitem"
+    | "log"
+    | "main"
+    | "marquee"
+    | "math"
+    | "menu"
+    | "menubar"
+    | "menuitem"
+    | "menuitemcheckbox"
+    | "menuitemradio"
+    | "navigation"
+    | "none"
+    | "note"
+    | "option"
+    | "presentation"
+    | "progressbar"
+    | "radio"
+    | "radiogroup"
+    | "region"
+    | "row"
+    | "rowgroup"
+    | "rowheader"
+    | "scrollbar"
+    | "search"
+    | "searchbox"
+    | "separator"
+    | "slider"
+    | "spinbutton"
+    | "status"
+    | "switch"
+    | "tab"
+    | "table"
+    | "tablist"
+    | "tabpanel"
+    | "term"
+    | "textbox"
+    | "timer"
+    | "toolbar"
+    | "tooltip"
+    | "tree"
+    | "treegrid"
+    | "treeitem"
+    | (string & {});
+
+  interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+    // React-specific Attributes
+    defaultChecked?: boolean | undefined;
+    defaultValue?: string | number | ReadonlyArray<string> | undefined;
+    suppressContentEditableWarning?: boolean | undefined;
+    suppressHydrationWarning?: boolean | undefined;
+
+    // Standard HTML Attributes
+    accessKey?: string | undefined;
+    className?: string | undefined;
+    contentEditable?: Booleanish | "inherit" | undefined;
+    contextMenu?: string | undefined;
+    dir?: string | undefined;
+    draggable?: Booleanish | undefined;
+    hidden?: boolean | undefined;
+    id?: string | undefined;
+    lang?: string | undefined;
+    placeholder?: string | undefined;
+    slot?: string | undefined;
+    spellCheck?: Booleanish | undefined;
+    style?: CSSProperties | undefined;
+    tabIndex?: number | undefined;
+    title?: string | undefined;
+    translate?: "yes" | "no" | undefined;
+
+    // Unknown
+    radioGroup?: string | undefined; // <command>, <menuitem>
+
+    // WAI-ARIA
+    role?: AriaRole | undefined;
+
+    // RDFa Attributes
+    about?: string | undefined;
+    datatype?: string | undefined;
+    inlist?: any;
+    prefix?: string | undefined;
+    property?: string | undefined;
+    resource?: string | undefined;
+    typeof?: string | undefined;
+    vocab?: string | undefined;
+
+    // Non-standard Attributes
+    autoCapitalize?: string | undefined;
+    autoCorrect?: string | undefined;
+    autoSave?: string | undefined;
+    color?: string | undefined;
+    itemProp?: string | undefined;
+    itemScope?: boolean | undefined;
+    itemType?: string | undefined;
+    itemID?: string | undefined;
+    itemRef?: string | undefined;
+    results?: number | undefined;
+    security?: string | undefined;
+    unselectable?: "on" | "off" | undefined;
+
+    // Living Standard
+    /**
+     * Hints at the type of data that might be entered by the user while editing the element or its contents
+     * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+     */
+    inputMode?:
+      | "none"
+      | "text"
+      | "tel"
+      | "url"
+      | "email"
+      | "numeric"
+      | "decimal"
+      | "search"
+      | undefined;
+    /**
+     * Specify that a standard HTML element should behave like a defined custom built-in element
+     * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+     */
+    is?: string | undefined;
+  }
+
+  interface AllHTMLAttributes<T> extends HTMLAttributes<T> {
+    // Standard HTML Attributes
+    accept?: string | undefined;
+    acceptCharset?: string | undefined;
+    action?: string | undefined;
+    allowFullScreen?: boolean | undefined;
+    allowTransparency?: boolean | undefined;
+    alt?: string | undefined;
+    as?: string | undefined;
+    async?: boolean | undefined;
+    autoComplete?: string | undefined;
+    autoFocus?: boolean | undefined;
+    autoPlay?: boolean | undefined;
+    capture?: boolean | "user" | "environment" | undefined;
+    cellPadding?: number | string | undefined;
+    cellSpacing?: number | string | undefined;
+    charSet?: string | undefined;
+    challenge?: string | undefined;
+    checked?: boolean | undefined;
+    cite?: string | undefined;
+    classID?: string | undefined;
+    cols?: number | undefined;
+    colSpan?: number | undefined;
+    content?: string | undefined;
+    controls?: boolean | undefined;
+    coords?: string | undefined;
+    crossOrigin?: string | undefined;
+    data?: string | undefined;
+    dateTime?: string | undefined;
+    default?: boolean | undefined;
+    defer?: boolean | undefined;
+    disabled?: boolean | undefined;
+    download?: any;
+    encType?: string | undefined;
+    form?: string | undefined;
+    formAction?: string | undefined;
+    formEncType?: string | undefined;
+    formMethod?: string | undefined;
+    formNoValidate?: boolean | undefined;
+    formTarget?: string | undefined;
+    frameBorder?: number | string | undefined;
+    headers?: string | undefined;
+    height?: number | string | undefined;
+    high?: number | undefined;
+    href?: string | undefined;
+    hrefLang?: string | undefined;
+    htmlFor?: string | undefined;
+    httpEquiv?: string | undefined;
+    integrity?: string | undefined;
+    keyParams?: string | undefined;
+    keyType?: string | undefined;
+    kind?: string | undefined;
+    label?: string | undefined;
+    list?: string | undefined;
+    loop?: boolean | undefined;
+    low?: number | undefined;
+    manifest?: string | undefined;
+    marginHeight?: number | undefined;
+    marginWidth?: number | undefined;
+    max?: number | string | undefined;
+    maxLength?: number | undefined;
+    media?: string | undefined;
+    mediaGroup?: string | undefined;
+    method?: string | undefined;
+    min?: number | string | undefined;
+    minLength?: number | undefined;
+    multiple?: boolean | undefined;
+    muted?: boolean | undefined;
+    name?: string | undefined;
+    nonce?: string | undefined;
+    noValidate?: boolean | undefined;
+    open?: boolean | undefined;
+    optimum?: number | undefined;
+    pattern?: string | undefined;
+    placeholder?: string | undefined;
+    playsInline?: boolean | undefined;
+    poster?: string | undefined;
+    preload?: string | undefined;
+    readOnly?: boolean | undefined;
+    rel?: string | undefined;
+    required?: boolean | undefined;
+    reversed?: boolean | undefined;
+    rows?: number | undefined;
+    rowSpan?: number | undefined;
+    sandbox?: string | undefined;
+    scope?: string | undefined;
+    scoped?: boolean | undefined;
+    scrolling?: string | undefined;
+    seamless?: boolean | undefined;
+    selected?: boolean | undefined;
+    shape?: string | undefined;
+    size?: number | undefined;
+    sizes?: string | undefined;
+    span?: number | undefined;
+    src?: string | undefined;
+    srcDoc?: string | undefined;
+    srcLang?: string | undefined;
+    srcSet?: string | undefined;
+    start?: number | undefined;
+    step?: number | string | undefined;
+    summary?: string | undefined;
+    target?: string | undefined;
+    type?: string | undefined;
+    useMap?: string | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+    width?: number | string | undefined;
+    wmode?: string | undefined;
+    wrap?: string | undefined;
+  }
+
+  type HTMLAttributeReferrerPolicy =
+    | ""
+    | "no-referrer"
+    | "no-referrer-when-downgrade"
+    | "origin"
+    | "origin-when-cross-origin"
+    | "same-origin"
+    | "strict-origin"
+    | "strict-origin-when-cross-origin"
+    | "unsafe-url";
+
+  type HTMLAttributeAnchorTarget =
+    | "_self"
+    | "_blank"
+    | "_parent"
+    | "_top"
+    | (string & {});
+
+  interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
+    download?: any;
+    href?: string | undefined;
+    hrefLang?: string | undefined;
+    media?: string | undefined;
+    ping?: string | undefined;
+    rel?: string | undefined;
+    target?: HTMLAttributeAnchorTarget | undefined;
+    type?: string | undefined;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+  }
+
+  interface AudioHTMLAttributes<T> extends MediaHTMLAttributes<T> {}
+
+  interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
+    alt?: string | undefined;
+    coords?: string | undefined;
+    download?: any;
+    href?: string | undefined;
+    hrefLang?: string | undefined;
+    media?: string | undefined;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    rel?: string | undefined;
+    shape?: string | undefined;
+    target?: string | undefined;
+  }
+
+  interface BaseHTMLAttributes<T> extends HTMLAttributes<T> {
+    href?: string | undefined;
+    target?: string | undefined;
+  }
+
+  interface BlockquoteHTMLAttributes<T> extends HTMLAttributes<T> {
+    cite?: string | undefined;
+  }
+
+  interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+    autoFocus?: boolean | undefined;
+    disabled?: boolean | undefined;
+    form?: string | undefined;
+    formAction?: string | undefined;
+    formEncType?: string | undefined;
+    formMethod?: string | undefined;
+    formNoValidate?: boolean | undefined;
+    formTarget?: string | undefined;
+    name?: string | undefined;
+    type?: "submit" | "reset" | "button" | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+  }
+
+  interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
+    height?: number | string | undefined;
+    width?: number | string | undefined;
+  }
+
+  interface ColHTMLAttributes<T> extends HTMLAttributes<T> {
+    span?: number | undefined;
+    width?: number | string | undefined;
+  }
+
+  interface ColgroupHTMLAttributes<T> extends HTMLAttributes<T> {
+    span?: number | undefined;
+  }
+
+  interface DataHTMLAttributes<T> extends HTMLAttributes<T> {
+    value?: string | ReadonlyArray<string> | number | undefined;
+  }
+
+  interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
+    open?: boolean | undefined;
+    onToggle?: ReactEventHandler<T> | undefined;
+  }
+
+  interface DelHTMLAttributes<T> extends HTMLAttributes<T> {
+    cite?: string | undefined;
+    dateTime?: string | undefined;
+  }
+
+  interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
+    open?: boolean | undefined;
+  }
+
+  interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
+    height?: number | string | undefined;
+    src?: string | undefined;
+    type?: string | undefined;
+    width?: number | string | undefined;
+  }
+
+  interface FieldsetHTMLAttributes<T> extends HTMLAttributes<T> {
+    disabled?: boolean | undefined;
+    form?: string | undefined;
+    name?: string | undefined;
+  }
+
+  interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
+    acceptCharset?: string | undefined;
+    action?: string | undefined;
+    autoComplete?: string | undefined;
+    encType?: string | undefined;
+    method?: string | undefined;
+    name?: string | undefined;
+    noValidate?: boolean | undefined;
+    target?: string | undefined;
+  }
+
+  interface HtmlHTMLAttributes<T> extends HTMLAttributes<T> {
+    manifest?: string | undefined;
+  }
+
+  interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
+    allow?: string | undefined;
+    allowFullScreen?: boolean | undefined;
+    allowTransparency?: boolean | undefined;
+    /** @deprecated */
+    frameBorder?: number | string | undefined;
+    height?: number | string | undefined;
+    loading?: "eager" | "lazy" | undefined;
+    /** @deprecated */
+    marginHeight?: number | undefined;
+    /** @deprecated */
+    marginWidth?: number | undefined;
+    name?: string | undefined;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    sandbox?: string | undefined;
+    /** @deprecated */
+    scrolling?: string | undefined;
+    seamless?: boolean | undefined;
+    src?: string | undefined;
+    srcDoc?: string | undefined;
+    width?: number | string | undefined;
+  }
+
+  interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
+    alt?: string | undefined;
+    crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+    decoding?: "async" | "auto" | "sync" | undefined;
+    height?: number | string | undefined;
+    loading?: "eager" | "lazy" | undefined;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    sizes?: string | undefined;
+    src?: string | undefined;
+    srcSet?: string | undefined;
+    useMap?: string | undefined;
+    width?: number | string | undefined;
+  }
+
+  interface InsHTMLAttributes<T> extends HTMLAttributes<T> {
+    cite?: string | undefined;
+    dateTime?: string | undefined;
+  }
+
+  type HTMLInputTypeAttribute =
+    | "button"
+    | "checkbox"
+    | "color"
+    | "date"
+    | "datetime-local"
+    | "email"
+    | "file"
+    | "hidden"
+    | "image"
+    | "month"
+    | "number"
+    | "password"
+    | "radio"
+    | "range"
+    | "reset"
+    | "search"
+    | "submit"
+    | "tel"
+    | "text"
+    | "time"
+    | "url"
+    | "week"
+    | (string & {});
+
+  interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
+    accept?: string | undefined;
+    alt?: string | undefined;
+    autoComplete?: string | undefined;
+    autoFocus?: boolean | undefined;
+    capture?: boolean | "user" | "environment" | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+    checked?: boolean | undefined;
+    crossOrigin?: string | undefined;
+    disabled?: boolean | undefined;
+    enterKeyHint?:
+      | "enter"
+      | "done"
+      | "go"
+      | "next"
+      | "previous"
+      | "search"
+      | "send"
+      | undefined;
+    form?: string | undefined;
+    formAction?: string | undefined;
+    formEncType?: string | undefined;
+    formMethod?: string | undefined;
+    formNoValidate?: boolean | undefined;
+    formTarget?: string | undefined;
+    height?: number | string | undefined;
+    list?: string | undefined;
+    max?: number | string | undefined;
+    maxLength?: number | undefined;
+    min?: number | string | undefined;
+    minLength?: number | undefined;
+    multiple?: boolean | undefined;
+    name?: string | undefined;
+    pattern?: string | undefined;
+    placeholder?: string | undefined;
+    readOnly?: boolean | undefined;
+    required?: boolean | undefined;
+    size?: number | undefined;
+    src?: string | undefined;
+    step?: number | string | undefined;
+    type?: HTMLInputTypeAttribute | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+    width?: number | string | undefined;
+
+    onChange?: ChangeEventHandler<T> | undefined;
+  }
+
+  interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
+    autoFocus?: boolean | undefined;
+    challenge?: string | undefined;
+    disabled?: boolean | undefined;
+    form?: string | undefined;
+    keyType?: string | undefined;
+    keyParams?: string | undefined;
+    name?: string | undefined;
+  }
+
+  interface LabelHTMLAttributes<T> extends HTMLAttributes<T> {
+    form?: string | undefined;
+    htmlFor?: string | undefined;
+  }
+
+  interface LiHTMLAttributes<T> extends HTMLAttributes<T> {
+    value?: string | ReadonlyArray<string> | number | undefined;
+  }
+
+  interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
+    as?: string | undefined;
+    crossOrigin?: string | undefined;
+    href?: string | undefined;
+    hrefLang?: string | undefined;
+    integrity?: string | undefined;
+    media?: string | undefined;
+    imageSrcSet?: string | undefined;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    rel?: string | undefined;
+    sizes?: string | undefined;
+    type?: string | undefined;
+    charSet?: string | undefined;
+  }
+
+  interface MapHTMLAttributes<T> extends HTMLAttributes<T> {
+    name?: string | undefined;
+  }
+
+  interface MenuHTMLAttributes<T> extends HTMLAttributes<T> {
+    type?: string | undefined;
+  }
+
+  interface MediaHTMLAttributes<T> extends HTMLAttributes<T> {
+    autoPlay?: boolean | undefined;
+    controls?: boolean | undefined;
+    controlsList?: string | undefined;
+    crossOrigin?: string | undefined;
+    loop?: boolean | undefined;
+    mediaGroup?: string | undefined;
+    muted?: boolean | undefined;
+    playsInline?: boolean | undefined;
+    preload?: string | undefined;
+    src?: string | undefined;
+  }
+
+  interface MetaHTMLAttributes<T> extends HTMLAttributes<T> {
+    charSet?: string | undefined;
+    content?: string | undefined;
+    httpEquiv?: string | undefined;
+    name?: string | undefined;
+    media?: string | undefined;
+  }
+
+  interface MeterHTMLAttributes<T> extends HTMLAttributes<T> {
+    form?: string | undefined;
+    high?: number | undefined;
+    low?: number | undefined;
+    max?: number | string | undefined;
+    min?: number | string | undefined;
+    optimum?: number | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+  }
+
+  interface QuoteHTMLAttributes<T> extends HTMLAttributes<T> {
+    cite?: string | undefined;
+  }
+
+  interface ObjectHTMLAttributes<T> extends HTMLAttributes<T> {
+    classID?: string | undefined;
+    data?: string | undefined;
+    form?: string | undefined;
+    height?: number | string | undefined;
+    name?: string | undefined;
+    type?: string | undefined;
+    useMap?: string | undefined;
+    width?: number | string | undefined;
+    wmode?: string | undefined;
+  }
+
+  interface OlHTMLAttributes<T> extends HTMLAttributes<T> {
+    reversed?: boolean | undefined;
+    start?: number | undefined;
+    type?: "1" | "a" | "A" | "i" | "I" | undefined;
+  }
+
+  interface OptgroupHTMLAttributes<T> extends HTMLAttributes<T> {
+    disabled?: boolean | undefined;
+    label?: string | undefined;
+  }
+
+  interface OptionHTMLAttributes<T> extends HTMLAttributes<T> {
+    disabled?: boolean | undefined;
+    label?: string | undefined;
+    selected?: boolean | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+  }
+
+  interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
+    form?: string | undefined;
+    htmlFor?: string | undefined;
+    name?: string | undefined;
+  }
+
+  interface ParamHTMLAttributes<T> extends HTMLAttributes<T> {
+    name?: string | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+  }
+
+  interface ProgressHTMLAttributes<T> extends HTMLAttributes<T> {
+    max?: number | string | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+  }
+
+  interface SlotHTMLAttributes<T> extends HTMLAttributes<T> {
+    name?: string | undefined;
+  }
+
+  interface ScriptHTMLAttributes<T> extends HTMLAttributes<T> {
+    async?: boolean | undefined;
+    /** @deprecated */
+    charSet?: string | undefined;
+    crossOrigin?: string | undefined;
+    defer?: boolean | undefined;
+    integrity?: string | undefined;
+    noModule?: boolean | undefined;
+    nonce?: string | undefined;
+    referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    src?: string | undefined;
+    type?: string | undefined;
+  }
+
+  interface SelectHTMLAttributes<T> extends HTMLAttributes<T> {
+    autoComplete?: string | undefined;
+    autoFocus?: boolean | undefined;
+    disabled?: boolean | undefined;
+    form?: string | undefined;
+    multiple?: boolean | undefined;
+    name?: string | undefined;
+    required?: boolean | undefined;
+    size?: number | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+    onChange?: ChangeEventHandler<T> | undefined;
+  }
+
+  interface SourceHTMLAttributes<T> extends HTMLAttributes<T> {
+    height?: number | string | undefined;
+    media?: string | undefined;
+    sizes?: string | undefined;
+    src?: string | undefined;
+    srcSet?: string | undefined;
+    type?: string | undefined;
+    width?: number | string | undefined;
+  }
+
+  interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+    media?: string | undefined;
+    nonce?: string | undefined;
+    scoped?: boolean | undefined;
+    type?: string | undefined;
+  }
+
+  interface TableHTMLAttributes<T> extends HTMLAttributes<T> {
+    cellPadding?: number | string | undefined;
+    cellSpacing?: number | string | undefined;
+    summary?: string | undefined;
+    width?: number | string | undefined;
+  }
+
+  interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
+    autoComplete?: string | undefined;
+    autoFocus?: boolean | undefined;
+    cols?: number | undefined;
+    dirName?: string | undefined;
+    disabled?: boolean | undefined;
+    form?: string | undefined;
+    maxLength?: number | undefined;
+    minLength?: number | undefined;
+    name?: string | undefined;
+    placeholder?: string | undefined;
+    readOnly?: boolean | undefined;
+    required?: boolean | undefined;
+    rows?: number | undefined;
+    value?: string | ReadonlyArray<string> | number | undefined;
+    wrap?: string | undefined;
+
+    onChange?: ChangeEventHandler<T> | undefined;
+  }
+
+  interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
+    align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+    colSpan?: number | undefined;
+    headers?: string | undefined;
+    rowSpan?: number | undefined;
+    scope?: string | undefined;
+    abbr?: string | undefined;
+    height?: number | string | undefined;
+    width?: number | string | undefined;
+    valign?: "top" | "middle" | "bottom" | "baseline" | undefined;
+  }
+
+  interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
+    align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+    colSpan?: number | undefined;
+    headers?: string | undefined;
+    rowSpan?: number | undefined;
+    scope?: string | undefined;
+    abbr?: string | undefined;
+  }
+
+  interface TimeHTMLAttributes<T> extends HTMLAttributes<T> {
+    dateTime?: string | undefined;
+  }
+
+  interface TrackHTMLAttributes<T> extends HTMLAttributes<T> {
+    default?: boolean | undefined;
+    kind?: string | undefined;
+    label?: string | undefined;
+    src?: string | undefined;
+    srcLang?: string | undefined;
+  }
+
+  interface VideoHTMLAttributes<T> extends MediaHTMLAttributes<T> {
+    height?: number | string | undefined;
+    playsInline?: boolean | undefined;
+    poster?: string | undefined;
+    width?: number | string | undefined;
+    disablePictureInPicture?: boolean | undefined;
+    disableRemotePlayback?: boolean | undefined;
+  }
+
+  // this list is "complete" in that it contains every SVG attribute
+  // that React supports, but the types can be improved.
+  // Full list here: https://facebook.github.io/react/docs/dom-elements.html
+  //
+  // The three broad type categories are (in order of restrictiveness):
+  //   - "number | string"
+  //   - "string"
+  //   - union of string literals
+  interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+    // Attributes which also defined in HTMLAttributes
+    // See comment in SVGDOMPropertyConfig.js
+    className?: string | undefined;
+    color?: string | undefined;
+    height?: number | string | undefined;
+    id?: string | undefined;
+    lang?: string | undefined;
+    max?: number | string | undefined;
+    media?: string | undefined;
+    method?: string | undefined;
+    min?: number | string | undefined;
+    name?: string | undefined;
+    style?: CSSProperties | undefined;
+    target?: string | undefined;
+    type?: string | undefined;
+    width?: number | string | undefined;
+
+    // Other HTML properties supported by SVG elements in browsers
+    role?: AriaRole | undefined;
+    tabIndex?: number | undefined;
+    crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+
+    // SVG Specific attributes
+    accentHeight?: number | string | undefined;
+    accumulate?: "none" | "sum" | undefined;
+    additive?: "replace" | "sum" | undefined;
+    alignmentBaseline?:
+      | "auto"
+      | "baseline"
+      | "before-edge"
+      | "text-before-edge"
+      | "middle"
+      | "central"
+      | "after-edge"
+      | "text-after-edge"
+      | "ideographic"
+      | "alphabetic"
+      | "hanging"
+      | "mathematical"
+      | "inherit"
+      | undefined;
+    allowReorder?: "no" | "yes" | undefined;
+    alphabetic?: number | string | undefined;
+    amplitude?: number | string | undefined;
+    arabicForm?: "initial" | "medial" | "terminal" | "isolated" | undefined;
+    ascent?: number | string | undefined;
+    attributeName?: string | undefined;
+    attributeType?: string | undefined;
+    autoReverse?: Booleanish | undefined;
+    azimuth?: number | string | undefined;
+    baseFrequency?: number | string | undefined;
+    baselineShift?: number | string | undefined;
+    baseProfile?: number | string | undefined;
+    bbox?: number | string | undefined;
+    begin?: number | string | undefined;
+    bias?: number | string | undefined;
+    by?: number | string | undefined;
+    calcMode?: number | string | undefined;
+    capHeight?: number | string | undefined;
+    clip?: number | string | undefined;
+    clipPath?: string | undefined;
+    clipPathUnits?: number | string | undefined;
+    clipRule?: number | string | undefined;
+    colorInterpolation?: number | string | undefined;
+    colorInterpolationFilters?:
+      | "auto"
+      | "sRGB"
+      | "linearRGB"
+      | "inherit"
+      | undefined;
+    colorProfile?: number | string | undefined;
+    colorRendering?: number | string | undefined;
+    contentScriptType?: number | string | undefined;
+    contentStyleType?: number | string | undefined;
+    cursor?: number | string | undefined;
+    cx?: number | string | undefined;
+    cy?: number | string | undefined;
+    d?: string | undefined;
+    decelerate?: number | string | undefined;
+    descent?: number | string | undefined;
+    diffuseConstant?: number | string | undefined;
+    direction?: number | string | undefined;
+    display?: number | string | undefined;
+    divisor?: number | string | undefined;
+    dominantBaseline?: number | string | undefined;
+    dur?: number | string | undefined;
+    dx?: number | string | undefined;
+    dy?: number | string | undefined;
+    edgeMode?: number | string | undefined;
+    elevation?: number | string | undefined;
+    enableBackground?: number | string | undefined;
+    end?: number | string | undefined;
+    exponent?: number | string | undefined;
+    externalResourcesRequired?: Booleanish | undefined;
+    fill?: string | undefined;
+    fillOpacity?: number | string | undefined;
+    fillRule?: "nonzero" | "evenodd" | "inherit" | undefined;
+    filter?: string | undefined;
+    filterRes?: number | string | undefined;
+    filterUnits?: number | string | undefined;
+    floodColor?: number | string | undefined;
+    floodOpacity?: number | string | undefined;
+    focusable?: Booleanish | "auto" | undefined;
+    fontFamily?: string | undefined;
+    fontSize?: number | string | undefined;
+    fontSizeAdjust?: number | string | undefined;
+    fontStretch?: number | string | undefined;
+    fontStyle?: number | string | undefined;
+    fontVariant?: number | string | undefined;
+    fontWeight?: number | string | undefined;
+    format?: number | string | undefined;
+    fr?: number | string | undefined;
+    from?: number | string | undefined;
+    fx?: number | string | undefined;
+    fy?: number | string | undefined;
+    g1?: number | string | undefined;
+    g2?: number | string | undefined;
+    glyphName?: number | string | undefined;
+    glyphOrientationHorizontal?: number | string | undefined;
+    glyphOrientationVertical?: number | string | undefined;
+    glyphRef?: number | string | undefined;
+    gradientTransform?: string | undefined;
+    gradientUnits?: string | undefined;
+    hanging?: number | string | undefined;
+    horizAdvX?: number | string | undefined;
+    horizOriginX?: number | string | undefined;
+    href?: string | undefined;
+    ideographic?: number | string | undefined;
+    imageRendering?: number | string | undefined;
+    in2?: number | string | undefined;
+    in?: string | undefined;
+    intercept?: number | string | undefined;
+    k1?: number | string | undefined;
+    k2?: number | string | undefined;
+    k3?: number | string | undefined;
+    k4?: number | string | undefined;
+    k?: number | string | undefined;
+    kernelMatrix?: number | string | undefined;
+    kernelUnitLength?: number | string | undefined;
+    kerning?: number | string | undefined;
+    keyPoints?: number | string | undefined;
+    keySplines?: number | string | undefined;
+    keyTimes?: number | string | undefined;
+    lengthAdjust?: number | string | undefined;
+    letterSpacing?: number | string | undefined;
+    lightingColor?: number | string | undefined;
+    limitingConeAngle?: number | string | undefined;
+    local?: number | string | undefined;
+    markerEnd?: string | undefined;
+    markerHeight?: number | string | undefined;
+    markerMid?: string | undefined;
+    markerStart?: string | undefined;
+    markerUnits?: number | string | undefined;
+    markerWidth?: number | string | undefined;
+    mask?: string | undefined;
+    maskContentUnits?: number | string | undefined;
+    maskUnits?: number | string | undefined;
+    mathematical?: number | string | undefined;
+    mode?: number | string | undefined;
+    numOctaves?: number | string | undefined;
+    offset?: number | string | undefined;
+    opacity?: number | string | undefined;
+    operator?: number | string | undefined;
+    order?: number | string | undefined;
+    orient?: number | string | undefined;
+    orientation?: number | string | undefined;
+    origin?: number | string | undefined;
+    overflow?: number | string | undefined;
+    overlinePosition?: number | string | undefined;
+    overlineThickness?: number | string | undefined;
+    paintOrder?: number | string | undefined;
+    panose1?: number | string | undefined;
+    path?: string | undefined;
+    pathLength?: number | string | undefined;
+    patternContentUnits?: string | undefined;
+    patternTransform?: number | string | undefined;
+    patternUnits?: string | undefined;
+    pointerEvents?: number | string | undefined;
+    points?: string | undefined;
+    pointsAtX?: number | string | undefined;
+    pointsAtY?: number | string | undefined;
+    pointsAtZ?: number | string | undefined;
+    preserveAlpha?: Booleanish | undefined;
+    preserveAspectRatio?: string | undefined;
+    primitiveUnits?: number | string | undefined;
+    r?: number | string | undefined;
+    radius?: number | string | undefined;
+    refX?: number | string | undefined;
+    refY?: number | string | undefined;
+    renderingIntent?: number | string | undefined;
+    repeatCount?: number | string | undefined;
+    repeatDur?: number | string | undefined;
+    requiredExtensions?: number | string | undefined;
+    requiredFeatures?: number | string | undefined;
+    restart?: number | string | undefined;
+    result?: string | undefined;
+    rotate?: number | string | undefined;
+    rx?: number | string | undefined;
+    ry?: number | string | undefined;
+    scale?: number | string | undefined;
+    seed?: number | string | undefined;
+    shapeRendering?: number | string | undefined;
+    slope?: number | string | undefined;
+    spacing?: number | string | undefined;
+    specularConstant?: number | string | undefined;
+    specularExponent?: number | string | undefined;
+    speed?: number | string | undefined;
+    spreadMethod?: string | undefined;
+    startOffset?: number | string | undefined;
+    stdDeviation?: number | string | undefined;
+    stemh?: number | string | undefined;
+    stemv?: number | string | undefined;
+    stitchTiles?: number | string | undefined;
+    stopColor?: string | undefined;
+    stopOpacity?: number | string | undefined;
+    strikethroughPosition?: number | string | undefined;
+    strikethroughThickness?: number | string | undefined;
+    string?: number | string | undefined;
+    stroke?: string | undefined;
+    strokeDasharray?: string | number | undefined;
+    strokeDashoffset?: string | number | undefined;
+    strokeLinecap?: "butt" | "round" | "square" | "inherit" | undefined;
+    strokeLinejoin?: "miter" | "round" | "bevel" | "inherit" | undefined;
+    strokeMiterlimit?: number | string | undefined;
+    strokeOpacity?: number | string | undefined;
+    strokeWidth?: number | string | undefined;
+    surfaceScale?: number | string | undefined;
+    systemLanguage?: number | string | undefined;
+    tableValues?: number | string | undefined;
+    targetX?: number | string | undefined;
+    targetY?: number | string | undefined;
+    textAnchor?: string | undefined;
+    textDecoration?: number | string | undefined;
+    textLength?: number | string | undefined;
+    textRendering?: number | string | undefined;
+    to?: number | string | undefined;
+    transform?: string | undefined;
+    u1?: number | string | undefined;
+    u2?: number | string | undefined;
+    underlinePosition?: number | string | undefined;
+    underlineThickness?: number | string | undefined;
+    unicode?: number | string | undefined;
+    unicodeBidi?: number | string | undefined;
+    unicodeRange?: number | string | undefined;
+    unitsPerEm?: number | string | undefined;
+    vAlphabetic?: number | string | undefined;
+    values?: string | undefined;
+    vectorEffect?: number | string | undefined;
+    version?: string | undefined;
+    vertAdvY?: number | string | undefined;
+    vertOriginX?: number | string | undefined;
+    vertOriginY?: number | string | undefined;
+    vHanging?: number | string | undefined;
+    vIdeographic?: number | string | undefined;
+    viewBox?: string | undefined;
+    viewTarget?: number | string | undefined;
+    visibility?: number | string | undefined;
+    vMathematical?: number | string | undefined;
+    widths?: number | string | undefined;
+    wordSpacing?: number | string | undefined;
+    writingMode?: number | string | undefined;
+    x1?: number | string | undefined;
+    x2?: number | string | undefined;
+    x?: number | string | undefined;
+    xChannelSelector?: string | undefined;
+    xHeight?: number | string | undefined;
+    xlinkActuate?: string | undefined;
+    xlinkArcrole?: string | undefined;
+    xlinkHref?: string | undefined;
+    xlinkRole?: string | undefined;
+    xlinkShow?: string | undefined;
+    xlinkTitle?: string | undefined;
+    xlinkType?: string | undefined;
+    xmlBase?: string | undefined;
+    xmlLang?: string | undefined;
+    xmlns?: string | undefined;
+    xmlnsXlink?: string | undefined;
+    xmlSpace?: string | undefined;
+    y1?: number | string | undefined;
+    y2?: number | string | undefined;
+    y?: number | string | undefined;
+    yChannelSelector?: string | undefined;
+    z?: number | string | undefined;
+    zoomAndPan?: string | undefined;
+  }
+
+  interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
+    allowFullScreen?: boolean | undefined;
+    allowpopups?: boolean | undefined;
+    autoFocus?: boolean | undefined;
+    autosize?: boolean | undefined;
+    blinkfeatures?: string | undefined;
+    disableblinkfeatures?: string | undefined;
+    disableguestresize?: boolean | undefined;
+    disablewebsecurity?: boolean | undefined;
+    guestinstance?: string | undefined;
+    httpreferrer?: string | undefined;
+    nodeintegration?: boolean | undefined;
+    partition?: string | undefined;
+    plugins?: boolean | undefined;
+    preload?: string | undefined;
+    src?: string | undefined;
+    useragent?: string | undefined;
+    webpreferences?: string | undefined;
+  }
+
+  //
+  // React.DOM
+  // ----------------------------------------------------------------------
+
+  interface ReactHTML {
+    a: DetailedHTMLFactory<
+      AnchorHTMLAttributes<HTMLAnchorElement>,
+      HTMLAnchorElement
+    >;
+    abbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    address: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    area: DetailedHTMLFactory<
+      AreaHTMLAttributes<HTMLAreaElement>,
+      HTMLAreaElement
+    >;
+    article: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    aside: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    audio: DetailedHTMLFactory<
+      AudioHTMLAttributes<HTMLAudioElement>,
+      HTMLAudioElement
+    >;
+    b: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    base: DetailedHTMLFactory<
+      BaseHTMLAttributes<HTMLBaseElement>,
+      HTMLBaseElement
+    >;
+    bdi: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    bdo: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    big: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    blockquote: DetailedHTMLFactory<
+      BlockquoteHTMLAttributes<HTMLQuoteElement>,
+      HTMLQuoteElement
+    >;
+    body: DetailedHTMLFactory<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
+    br: DetailedHTMLFactory<HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
+    button: DetailedHTMLFactory<
+      ButtonHTMLAttributes<HTMLButtonElement>,
+      HTMLButtonElement
+    >;
+    canvas: DetailedHTMLFactory<
+      CanvasHTMLAttributes<HTMLCanvasElement>,
+      HTMLCanvasElement
+    >;
+    caption: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    cite: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    code: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    col: DetailedHTMLFactory<
+      ColHTMLAttributes<HTMLTableColElement>,
+      HTMLTableColElement
+    >;
+    colgroup: DetailedHTMLFactory<
+      ColgroupHTMLAttributes<HTMLTableColElement>,
+      HTMLTableColElement
+    >;
+    data: DetailedHTMLFactory<
+      DataHTMLAttributes<HTMLDataElement>,
+      HTMLDataElement
+    >;
+    datalist: DetailedHTMLFactory<
+      HTMLAttributes<HTMLDataListElement>,
+      HTMLDataListElement
+    >;
+    dd: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    del: DetailedHTMLFactory<DelHTMLAttributes<HTMLModElement>, HTMLModElement>;
+    details: DetailedHTMLFactory<
+      DetailsHTMLAttributes<HTMLDetailsElement>,
+      HTMLDetailsElement
+    >;
+    dfn: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    dialog: DetailedHTMLFactory<
+      DialogHTMLAttributes<HTMLDialogElement>,
+      HTMLDialogElement
+    >;
+    div: DetailedHTMLFactory<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+    dl: DetailedHTMLFactory<HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
+    dt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    em: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    embed: DetailedHTMLFactory<
+      EmbedHTMLAttributes<HTMLEmbedElement>,
+      HTMLEmbedElement
+    >;
+    fieldset: DetailedHTMLFactory<
+      FieldsetHTMLAttributes<HTMLFieldSetElement>,
+      HTMLFieldSetElement
+    >;
+    figcaption: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    figure: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    footer: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    form: DetailedHTMLFactory<
+      FormHTMLAttributes<HTMLFormElement>,
+      HTMLFormElement
+    >;
+    h1: DetailedHTMLFactory<
+      HTMLAttributes<HTMLHeadingElement>,
+      HTMLHeadingElement
+    >;
+    h2: DetailedHTMLFactory<
+      HTMLAttributes<HTMLHeadingElement>,
+      HTMLHeadingElement
+    >;
+    h3: DetailedHTMLFactory<
+      HTMLAttributes<HTMLHeadingElement>,
+      HTMLHeadingElement
+    >;
+    h4: DetailedHTMLFactory<
+      HTMLAttributes<HTMLHeadingElement>,
+      HTMLHeadingElement
+    >;
+    h5: DetailedHTMLFactory<
+      HTMLAttributes<HTMLHeadingElement>,
+      HTMLHeadingElement
+    >;
+    h6: DetailedHTMLFactory<
+      HTMLAttributes<HTMLHeadingElement>,
+      HTMLHeadingElement
+    >;
+    head: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLHeadElement>;
+    header: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    hgroup: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    hr: DetailedHTMLFactory<HTMLAttributes<HTMLHRElement>, HTMLHRElement>;
+    html: DetailedHTMLFactory<
+      HtmlHTMLAttributes<HTMLHtmlElement>,
+      HTMLHtmlElement
+    >;
+    i: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    iframe: DetailedHTMLFactory<
+      IframeHTMLAttributes<HTMLIFrameElement>,
+      HTMLIFrameElement
+    >;
+    img: DetailedHTMLFactory<
+      ImgHTMLAttributes<HTMLImageElement>,
+      HTMLImageElement
+    >;
+    input: DetailedHTMLFactory<
+      InputHTMLAttributes<HTMLInputElement>,
+      HTMLInputElement
+    >;
+    ins: DetailedHTMLFactory<InsHTMLAttributes<HTMLModElement>, HTMLModElement>;
+    kbd: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    keygen: DetailedHTMLFactory<KeygenHTMLAttributes<HTMLElement>, HTMLElement>;
+    label: DetailedHTMLFactory<
+      LabelHTMLAttributes<HTMLLabelElement>,
+      HTMLLabelElement
+    >;
+    legend: DetailedHTMLFactory<
+      HTMLAttributes<HTMLLegendElement>,
+      HTMLLegendElement
+    >;
+    li: DetailedHTMLFactory<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>;
+    link: DetailedHTMLFactory<
+      LinkHTMLAttributes<HTMLLinkElement>,
+      HTMLLinkElement
+    >;
+    main: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    map: DetailedHTMLFactory<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement>;
+    mark: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    menu: DetailedHTMLFactory<MenuHTMLAttributes<HTMLElement>, HTMLElement>;
+    menuitem: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    meta: DetailedHTMLFactory<
+      MetaHTMLAttributes<HTMLMetaElement>,
+      HTMLMetaElement
+    >;
+    meter: DetailedHTMLFactory<
+      MeterHTMLAttributes<HTMLMeterElement>,
+      HTMLMeterElement
+    >;
+    nav: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    noscript: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    object: DetailedHTMLFactory<
+      ObjectHTMLAttributes<HTMLObjectElement>,
+      HTMLObjectElement
+    >;
+    ol: DetailedHTMLFactory<
+      OlHTMLAttributes<HTMLOListElement>,
+      HTMLOListElement
+    >;
+    optgroup: DetailedHTMLFactory<
+      OptgroupHTMLAttributes<HTMLOptGroupElement>,
+      HTMLOptGroupElement
+    >;
+    option: DetailedHTMLFactory<
+      OptionHTMLAttributes<HTMLOptionElement>,
+      HTMLOptionElement
+    >;
+    output: DetailedHTMLFactory<
+      OutputHTMLAttributes<HTMLOutputElement>,
+      HTMLOutputElement
+    >;
+    p: DetailedHTMLFactory<
+      HTMLAttributes<HTMLParagraphElement>,
+      HTMLParagraphElement
+    >;
+    param: DetailedHTMLFactory<
+      ParamHTMLAttributes<HTMLParamElement>,
+      HTMLParamElement
+    >;
+    picture: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    pre: DetailedHTMLFactory<HTMLAttributes<HTMLPreElement>, HTMLPreElement>;
+    progress: DetailedHTMLFactory<
+      ProgressHTMLAttributes<HTMLProgressElement>,
+      HTMLProgressElement
+    >;
+    q: DetailedHTMLFactory<
+      QuoteHTMLAttributes<HTMLQuoteElement>,
+      HTMLQuoteElement
+    >;
+    rp: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    rt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    ruby: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    s: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    samp: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    slot: DetailedHTMLFactory<
+      SlotHTMLAttributes<HTMLSlotElement>,
+      HTMLSlotElement
+    >;
+    script: DetailedHTMLFactory<
+      ScriptHTMLAttributes<HTMLScriptElement>,
+      HTMLScriptElement
+    >;
+    section: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    select: DetailedHTMLFactory<
+      SelectHTMLAttributes<HTMLSelectElement>,
+      HTMLSelectElement
+    >;
+    small: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    source: DetailedHTMLFactory<
+      SourceHTMLAttributes<HTMLSourceElement>,
+      HTMLSourceElement
+    >;
+    span: DetailedHTMLFactory<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>;
+    strong: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    style: DetailedHTMLFactory<
+      StyleHTMLAttributes<HTMLStyleElement>,
+      HTMLStyleElement
+    >;
+    sub: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    summary: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    sup: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    table: DetailedHTMLFactory<
+      TableHTMLAttributes<HTMLTableElement>,
+      HTMLTableElement
+    >;
+    template: DetailedHTMLFactory<
+      HTMLAttributes<HTMLTemplateElement>,
+      HTMLTemplateElement
+    >;
+    tbody: DetailedHTMLFactory<
+      HTMLAttributes<HTMLTableSectionElement>,
+      HTMLTableSectionElement
+    >;
+    td: DetailedHTMLFactory<
+      TdHTMLAttributes<HTMLTableDataCellElement>,
+      HTMLTableDataCellElement
+    >;
+    textarea: DetailedHTMLFactory<
+      TextareaHTMLAttributes<HTMLTextAreaElement>,
+      HTMLTextAreaElement
+    >;
+    tfoot: DetailedHTMLFactory<
+      HTMLAttributes<HTMLTableSectionElement>,
+      HTMLTableSectionElement
+    >;
+    th: DetailedHTMLFactory<
+      ThHTMLAttributes<HTMLTableHeaderCellElement>,
+      HTMLTableHeaderCellElement
+    >;
+    thead: DetailedHTMLFactory<
+      HTMLAttributes<HTMLTableSectionElement>,
+      HTMLTableSectionElement
+    >;
+    time: DetailedHTMLFactory<
+      TimeHTMLAttributes<HTMLTimeElement>,
+      HTMLTimeElement
+    >;
+    title: DetailedHTMLFactory<
+      HTMLAttributes<HTMLTitleElement>,
+      HTMLTitleElement
+    >;
+    tr: DetailedHTMLFactory<
+      HTMLAttributes<HTMLTableRowElement>,
+      HTMLTableRowElement
+    >;
+    track: DetailedHTMLFactory<
+      TrackHTMLAttributes<HTMLTrackElement>,
+      HTMLTrackElement
+    >;
+    u: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    ul: DetailedHTMLFactory<HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
+    var: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    video: DetailedHTMLFactory<
+      VideoHTMLAttributes<HTMLVideoElement>,
+      HTMLVideoElement
+    >;
+    wbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+    webview: DetailedHTMLFactory<
+      WebViewHTMLAttributes<HTMLWebViewElement>,
+      HTMLWebViewElement
+    >;
+  }
+
+  interface ReactSVG {
+    animate: SVGFactory;
+    circle: SVGFactory;
+    clipPath: SVGFactory;
+    defs: SVGFactory;
+    desc: SVGFactory;
+    ellipse: SVGFactory;
+    feBlend: SVGFactory;
+    feColorMatrix: SVGFactory;
+    feComponentTransfer: SVGFactory;
+    feComposite: SVGFactory;
+    feConvolveMatrix: SVGFactory;
+    feDiffuseLighting: SVGFactory;
+    feDisplacementMap: SVGFactory;
+    feDistantLight: SVGFactory;
+    feDropShadow: SVGFactory;
+    feFlood: SVGFactory;
+    feFuncA: SVGFactory;
+    feFuncB: SVGFactory;
+    feFuncG: SVGFactory;
+    feFuncR: SVGFactory;
+    feGaussianBlur: SVGFactory;
+    feImage: SVGFactory;
+    feMerge: SVGFactory;
+    feMergeNode: SVGFactory;
+    feMorphology: SVGFactory;
+    feOffset: SVGFactory;
+    fePointLight: SVGFactory;
+    feSpecularLighting: SVGFactory;
+    feSpotLight: SVGFactory;
+    feTile: SVGFactory;
+    feTurbulence: SVGFactory;
+    filter: SVGFactory;
+    foreignObject: SVGFactory;
+    g: SVGFactory;
+    image: SVGFactory;
+    line: SVGFactory;
+    linearGradient: SVGFactory;
+    marker: SVGFactory;
+    mask: SVGFactory;
+    metadata: SVGFactory;
+    path: SVGFactory;
+    pattern: SVGFactory;
+    polygon: SVGFactory;
+    polyline: SVGFactory;
+    radialGradient: SVGFactory;
+    rect: SVGFactory;
+    stop: SVGFactory;
+    svg: SVGFactory;
+    switch: SVGFactory;
+    symbol: SVGFactory;
+    text: SVGFactory;
+    textPath: SVGFactory;
+    tspan: SVGFactory;
+    use: SVGFactory;
+    view: SVGFactory;
+  }
+
+  interface ReactDOM extends ReactHTML, ReactSVG {}
+
+  //
+  // React.PropTypes
+  // ----------------------------------------------------------------------
+
+  type Validator<T> = PropTypes.Validator<T>;
+
+  type Requireable<T> = PropTypes.Requireable<T>;
+
+  type ValidationMap<T> = PropTypes.ValidationMap<T>;
+
+  type WeakValidationMap<T> = {
+    [K in keyof T]?: null extends T[K]
+      ? Validator<T[K] | null | undefined>
+      : undefined extends T[K]
+      ? Validator<T[K] | null | undefined>
+      : Validator<T[K]>;
+  };
+
+  interface ReactPropTypes {
+    any: typeof PropTypes.any;
+    array: typeof PropTypes.array;
+    bool: typeof PropTypes.bool;
+    func: typeof PropTypes.func;
+    number: typeof PropTypes.number;
+    object: typeof PropTypes.object;
+    string: typeof PropTypes.string;
+    node: typeof PropTypes.node;
+    element: typeof PropTypes.element;
+    instanceOf: typeof PropTypes.instanceOf;
+    oneOf: typeof PropTypes.oneOf;
+    oneOfType: typeof PropTypes.oneOfType;
+    arrayOf: typeof PropTypes.arrayOf;
+    objectOf: typeof PropTypes.objectOf;
+    shape: typeof PropTypes.shape;
+    exact: typeof PropTypes.exact;
+  }
+
+  //
+  // React.Children
+  // ----------------------------------------------------------------------
+
+  /**
+   * @deprecated - Use `typeof React.Children` instead.
+   */
+  // Sync with type of `const Children`.
+  interface ReactChildren {
+    map<T, C>(
+      children: C | ReadonlyArray<C>,
+      fn: (child: C, index: number) => T
+    ): C extends null | undefined
+      ? C
+      : Array<Exclude<T, boolean | null | undefined>>;
+    forEach<C>(
+      children: C | ReadonlyArray<C>,
+      fn: (child: C, index: number) => void
+    ): void;
+    count(children: any): number;
+    only<C>(children: C): C extends any[] ? never : C;
+    toArray(
+      children: ReactNode | ReactNode[]
+    ): Array<Exclude<ReactNode, boolean | null | undefined>>;
+  }
+
+  //
+  // Browser Interfaces
+  // https://github.com/nikeee/2048-typescript/blob/master/2048/js/touch.d.ts
+  // ----------------------------------------------------------------------
+
+  interface AbstractView {
+    styleMedia: StyleMedia;
+    document: Document;
+  }
+
+  interface Touch {
+    identifier: number;
+    target: EventTarget;
+    screenX: number;
+    screenY: number;
+    clientX: number;
+    clientY: number;
+    pageX: number;
+    pageY: number;
+  }
+
+  interface TouchList {
+    [index: number]: Touch;
+    length: number;
+    item(index: number): Touch;
+    identifiedTouch(identifier: number): Touch;
+  }
+
+  //
+  // Error Interfaces
+  // ----------------------------------------------------------------------
+  interface ErrorInfo {
+    /**
+     * Captures which component contained the exception, and its ancestors.
+     */
+    componentStack: string;
+  }
+}
+
+// naked 'any' type in a conditional type will short circuit and union both the then/else branches
+// so boolean is only resolved for T = any
+type IsExactlyAny<T> = boolean extends (T extends never ? true : false)
+  ? true
+  : false;
+
+type ExactlyAnyPropertyKeys<T> = {
+  [K in keyof T]: IsExactlyAny<T[K]> extends true ? K : never;
+}[keyof T];
+type NotExactlyAnyPropertyKeys<T> = Exclude<keyof T, ExactlyAnyPropertyKeys<T>>;
+
+// Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
+type MergePropTypes<P, T> =
+  // Distribute over P in case it is a union type
+  P extends any
+    ? // If props is type any, use propTypes definitions
+      IsExactlyAny<P> extends true
+      ? T
+      : // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
+      string extends keyof P
+      ? P
+      : // Prefer declared types which are not exactly any
+        Pick<P, NotExactlyAnyPropertyKeys<P>> &
+          // For props which are exactly any, use the type inferred from propTypes if present
+          Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>> &
+          // Keep leftover props not specified in propTypes
+          Pick<P, Exclude<keyof P, keyof T>>
+    : never;
+
+type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
+
+// Any prop that has a default prop becomes optional, but its type is unchanged
+// Undeclared default props are augmented into the resulting allowable attributes
+// If declared props have indexed properties, ignore default props entirely as keyof gets widened
+// Wrap in an outer-level conditional type to allow distribution over props that are unions
+type Defaultize<P, D> = P extends any
+  ? string extends keyof P
+    ? P
+    : Pick<P, Exclude<keyof P, keyof D>> &
+        InexactPartial<Pick<P, Extract<keyof P, keyof D>>> &
+        InexactPartial<Pick<D, Exclude<keyof D, keyof P>>>
+  : never;
+
+type ReactManagedAttributes<C, P> = C extends {
+  propTypes: infer T;
+  defaultProps: infer D;
+}
+  ? Defaultize<MergePropTypes<P, PropTypes.InferProps<T>>, D>
+  : C extends { propTypes: infer T }
+  ? MergePropTypes<P, PropTypes.InferProps<T>>
+  : C extends { defaultProps: infer D }
+  ? Defaultize<P, D>
+  : P;
+
+declare global {
+  namespace JSX {
+    interface Element extends React.ReactElement<any, any> {}
+    interface ElementClass extends React.Component<any> {
+      render(): React.ReactNode;
+    }
+    interface ElementAttributesProperty {
+      props: {};
+    }
+    interface ElementChildrenAttribute {
+      children: {};
+    }
+
+    // We can't recurse forever because `type` can't be self-referential;
+    // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
+    type LibraryManagedAttributes<C, P> = C extends
+      | React.MemoExoticComponent<infer T>
+      | React.LazyExoticComponent<infer T>
+      ? T extends
+          | React.MemoExoticComponent<infer U>
+          | React.LazyExoticComponent<infer U>
+        ? ReactManagedAttributes<U, P>
+        : ReactManagedAttributes<T, P>
+      : ReactManagedAttributes<C, P>;
+
+    interface IntrinsicAttributes extends React.Attributes {}
+    interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> {}
+
+    interface IntrinsicElements {
+      // HTML
+      a: React.DetailedHTMLProps<
+        React.AnchorHTMLAttributes<HTMLAnchorElement>,
+        HTMLAnchorElement
+      >;
+      abbr: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      address: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      area: React.DetailedHTMLProps<
+        React.AreaHTMLAttributes<HTMLAreaElement>,
+        HTMLAreaElement
+      >;
+      article: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      aside: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      audio: React.DetailedHTMLProps<
+        React.AudioHTMLAttributes<HTMLAudioElement>,
+        HTMLAudioElement
+      >;
+      b: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      base: React.DetailedHTMLProps<
+        React.BaseHTMLAttributes<HTMLBaseElement>,
+        HTMLBaseElement
+      >;
+      bdi: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      bdo: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      big: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      blockquote: React.DetailedHTMLProps<
+        React.BlockquoteHTMLAttributes<HTMLQuoteElement>,
+        HTMLQuoteElement
+      >;
+      body: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLBodyElement>,
+        HTMLBodyElement
+      >;
+      br: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLBRElement>,
+        HTMLBRElement
+      >;
+      button: React.DetailedHTMLProps<
+        React.ButtonHTMLAttributes<HTMLButtonElement>,
+        HTMLButtonElement
+      >;
+      canvas: React.DetailedHTMLProps<
+        React.CanvasHTMLAttributes<HTMLCanvasElement>,
+        HTMLCanvasElement
+      >;
+      caption: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      cite: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      code: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      col: React.DetailedHTMLProps<
+        React.ColHTMLAttributes<HTMLTableColElement>,
+        HTMLTableColElement
+      >;
+      colgroup: React.DetailedHTMLProps<
+        React.ColgroupHTMLAttributes<HTMLTableColElement>,
+        HTMLTableColElement
+      >;
+      data: React.DetailedHTMLProps<
+        React.DataHTMLAttributes<HTMLDataElement>,
+        HTMLDataElement
+      >;
+      datalist: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLDataListElement>,
+        HTMLDataListElement
+      >;
+      dd: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      del: React.DetailedHTMLProps<
+        React.DelHTMLAttributes<HTMLModElement>,
+        HTMLModElement
+      >;
+      details: React.DetailedHTMLProps<
+        React.DetailsHTMLAttributes<HTMLDetailsElement>,
+        HTMLDetailsElement
+      >;
+      dfn: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      dialog: React.DetailedHTMLProps<
+        React.DialogHTMLAttributes<HTMLDialogElement>,
+        HTMLDialogElement
+      >;
+      div: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLDivElement>,
+        HTMLDivElement
+      >;
+      dl: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLDListElement>,
+        HTMLDListElement
+      >;
+      dt: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      em: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      embed: React.DetailedHTMLProps<
+        React.EmbedHTMLAttributes<HTMLEmbedElement>,
+        HTMLEmbedElement
+      >;
+      fieldset: React.DetailedHTMLProps<
+        React.FieldsetHTMLAttributes<HTMLFieldSetElement>,
+        HTMLFieldSetElement
+      >;
+      figcaption: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      figure: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      footer: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      form: React.DetailedHTMLProps<
+        React.FormHTMLAttributes<HTMLFormElement>,
+        HTMLFormElement
+      >;
+      h1: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHeadingElement>,
+        HTMLHeadingElement
+      >;
+      h2: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHeadingElement>,
+        HTMLHeadingElement
+      >;
+      h3: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHeadingElement>,
+        HTMLHeadingElement
+      >;
+      h4: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHeadingElement>,
+        HTMLHeadingElement
+      >;
+      h5: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHeadingElement>,
+        HTMLHeadingElement
+      >;
+      h6: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHeadingElement>,
+        HTMLHeadingElement
+      >;
+      head: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHeadElement>,
+        HTMLHeadElement
+      >;
+      header: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      hgroup: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      hr: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLHRElement>,
+        HTMLHRElement
+      >;
+      html: React.DetailedHTMLProps<
+        React.HtmlHTMLAttributes<HTMLHtmlElement>,
+        HTMLHtmlElement
+      >;
+      i: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      iframe: React.DetailedHTMLProps<
+        React.IframeHTMLAttributes<HTMLIFrameElement>,
+        HTMLIFrameElement
+      >;
+      img: React.DetailedHTMLProps<
+        React.ImgHTMLAttributes<HTMLImageElement>,
+        HTMLImageElement
+      >;
+      input: React.DetailedHTMLProps<
+        React.InputHTMLAttributes<HTMLInputElement>,
+        HTMLInputElement
+      >;
+      ins: React.DetailedHTMLProps<
+        React.InsHTMLAttributes<HTMLModElement>,
+        HTMLModElement
+      >;
+      kbd: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      keygen: React.DetailedHTMLProps<
+        React.KeygenHTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      label: React.DetailedHTMLProps<
+        React.LabelHTMLAttributes<HTMLLabelElement>,
+        HTMLLabelElement
+      >;
+      legend: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLLegendElement>,
+        HTMLLegendElement
+      >;
+      li: React.DetailedHTMLProps<
+        React.LiHTMLAttributes<HTMLLIElement>,
+        HTMLLIElement
+      >;
+      link: React.DetailedHTMLProps<
+        React.LinkHTMLAttributes<HTMLLinkElement>,
+        HTMLLinkElement
+      >;
+      main: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      map: React.DetailedHTMLProps<
+        React.MapHTMLAttributes<HTMLMapElement>,
+        HTMLMapElement
+      >;
+      mark: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      menu: React.DetailedHTMLProps<
+        React.MenuHTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      menuitem: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      meta: React.DetailedHTMLProps<
+        React.MetaHTMLAttributes<HTMLMetaElement>,
+        HTMLMetaElement
+      >;
+      meter: React.DetailedHTMLProps<
+        React.MeterHTMLAttributes<HTMLMeterElement>,
+        HTMLMeterElement
+      >;
+      nav: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      noindex: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      noscript: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      object: React.DetailedHTMLProps<
+        React.ObjectHTMLAttributes<HTMLObjectElement>,
+        HTMLObjectElement
+      >;
+      ol: React.DetailedHTMLProps<
+        React.OlHTMLAttributes<HTMLOListElement>,
+        HTMLOListElement
+      >;
+      optgroup: React.DetailedHTMLProps<
+        React.OptgroupHTMLAttributes<HTMLOptGroupElement>,
+        HTMLOptGroupElement
+      >;
+      option: React.DetailedHTMLProps<
+        React.OptionHTMLAttributes<HTMLOptionElement>,
+        HTMLOptionElement
+      >;
+      output: React.DetailedHTMLProps<
+        React.OutputHTMLAttributes<HTMLOutputElement>,
+        HTMLOutputElement
+      >;
+      p: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLParagraphElement>,
+        HTMLParagraphElement
+      >;
+      param: React.DetailedHTMLProps<
+        React.ParamHTMLAttributes<HTMLParamElement>,
+        HTMLParamElement
+      >;
+      picture: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      pre: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLPreElement>,
+        HTMLPreElement
+      >;
+      progress: React.DetailedHTMLProps<
+        React.ProgressHTMLAttributes<HTMLProgressElement>,
+        HTMLProgressElement
+      >;
+      q: React.DetailedHTMLProps<
+        React.QuoteHTMLAttributes<HTMLQuoteElement>,
+        HTMLQuoteElement
+      >;
+      rp: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      rt: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      ruby: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      s: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      samp: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      slot: React.DetailedHTMLProps<
+        React.SlotHTMLAttributes<HTMLSlotElement>,
+        HTMLSlotElement
+      >;
+      script: React.DetailedHTMLProps<
+        React.ScriptHTMLAttributes<HTMLScriptElement>,
+        HTMLScriptElement
+      >;
+      section: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      select: React.DetailedHTMLProps<
+        React.SelectHTMLAttributes<HTMLSelectElement>,
+        HTMLSelectElement
+      >;
+      small: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      source: React.DetailedHTMLProps<
+        React.SourceHTMLAttributes<HTMLSourceElement>,
+        HTMLSourceElement
+      >;
+      span: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLSpanElement>,
+        HTMLSpanElement
+      >;
+      strong: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      style: React.DetailedHTMLProps<
+        React.StyleHTMLAttributes<HTMLStyleElement>,
+        HTMLStyleElement
+      >;
+      sub: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      summary: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      sup: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      table: React.DetailedHTMLProps<
+        React.TableHTMLAttributes<HTMLTableElement>,
+        HTMLTableElement
+      >;
+      template: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLTemplateElement>,
+        HTMLTemplateElement
+      >;
+      tbody: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLTableSectionElement>,
+        HTMLTableSectionElement
+      >;
+      td: React.DetailedHTMLProps<
+        React.TdHTMLAttributes<HTMLTableDataCellElement>,
+        HTMLTableDataCellElement
+      >;
+      textarea: React.DetailedHTMLProps<
+        React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+        HTMLTextAreaElement
+      >;
+      tfoot: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLTableSectionElement>,
+        HTMLTableSectionElement
+      >;
+      th: React.DetailedHTMLProps<
+        React.ThHTMLAttributes<HTMLTableHeaderCellElement>,
+        HTMLTableHeaderCellElement
+      >;
+      thead: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLTableSectionElement>,
+        HTMLTableSectionElement
+      >;
+      time: React.DetailedHTMLProps<
+        React.TimeHTMLAttributes<HTMLTimeElement>,
+        HTMLTimeElement
+      >;
+      title: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLTitleElement>,
+        HTMLTitleElement
+      >;
+      tr: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLTableRowElement>,
+        HTMLTableRowElement
+      >;
+      track: React.DetailedHTMLProps<
+        React.TrackHTMLAttributes<HTMLTrackElement>,
+        HTMLTrackElement
+      >;
+      u: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      ul: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLUListElement>,
+        HTMLUListElement
+      >;
+      var: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      video: React.DetailedHTMLProps<
+        React.VideoHTMLAttributes<HTMLVideoElement>,
+        HTMLVideoElement
+      >;
+      wbr: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+      webview: React.DetailedHTMLProps<
+        React.WebViewHTMLAttributes<HTMLWebViewElement>,
+        HTMLWebViewElement
+      >;
+
+      // SVG
+      svg: React.SVGProps<SVGSVGElement>;
+
+      animate: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateElement but is not in TypeScript's lib.dom.d.ts for now.
+      animateMotion: React.SVGProps<SVGElement>;
+      animateTransform: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateTransformElement but is not in TypeScript's lib.dom.d.ts for now.
+      circle: React.SVGProps<SVGCircleElement>;
+      clipPath: React.SVGProps<SVGClipPathElement>;
+      defs: React.SVGProps<SVGDefsElement>;
+      desc: React.SVGProps<SVGDescElement>;
+      ellipse: React.SVGProps<SVGEllipseElement>;
+      feBlend: React.SVGProps<SVGFEBlendElement>;
+      feColorMatrix: React.SVGProps<SVGFEColorMatrixElement>;
+      feComponentTransfer: React.SVGProps<SVGFEComponentTransferElement>;
+      feComposite: React.SVGProps<SVGFECompositeElement>;
+      feConvolveMatrix: React.SVGProps<SVGFEConvolveMatrixElement>;
+      feDiffuseLighting: React.SVGProps<SVGFEDiffuseLightingElement>;
+      feDisplacementMap: React.SVGProps<SVGFEDisplacementMapElement>;
+      feDistantLight: React.SVGProps<SVGFEDistantLightElement>;
+      feDropShadow: React.SVGProps<SVGFEDropShadowElement>;
+      feFlood: React.SVGProps<SVGFEFloodElement>;
+      feFuncA: React.SVGProps<SVGFEFuncAElement>;
+      feFuncB: React.SVGProps<SVGFEFuncBElement>;
+      feFuncG: React.SVGProps<SVGFEFuncGElement>;
+      feFuncR: React.SVGProps<SVGFEFuncRElement>;
+      feGaussianBlur: React.SVGProps<SVGFEGaussianBlurElement>;
+      feImage: React.SVGProps<SVGFEImageElement>;
+      feMerge: React.SVGProps<SVGFEMergeElement>;
+      feMergeNode: React.SVGProps<SVGFEMergeNodeElement>;
+      feMorphology: React.SVGProps<SVGFEMorphologyElement>;
+      feOffset: React.SVGProps<SVGFEOffsetElement>;
+      fePointLight: React.SVGProps<SVGFEPointLightElement>;
+      feSpecularLighting: React.SVGProps<SVGFESpecularLightingElement>;
+      feSpotLight: React.SVGProps<SVGFESpotLightElement>;
+      feTile: React.SVGProps<SVGFETileElement>;
+      feTurbulence: React.SVGProps<SVGFETurbulenceElement>;
+      filter: React.SVGProps<SVGFilterElement>;
+      foreignObject: React.SVGProps<SVGForeignObjectElement>;
+      g: React.SVGProps<SVGGElement>;
+      image: React.SVGProps<SVGImageElement>;
+      line: React.SVGProps<SVGLineElement>;
+      linearGradient: React.SVGProps<SVGLinearGradientElement>;
+      marker: React.SVGProps<SVGMarkerElement>;
+      mask: React.SVGProps<SVGMaskElement>;
+      metadata: React.SVGProps<SVGMetadataElement>;
+      mpath: React.SVGProps<SVGElement>;
+      path: React.SVGProps<SVGPathElement>;
+      pattern: React.SVGProps<SVGPatternElement>;
+      polygon: React.SVGProps<SVGPolygonElement>;
+      polyline: React.SVGProps<SVGPolylineElement>;
+      radialGradient: React.SVGProps<SVGRadialGradientElement>;
+      rect: React.SVGProps<SVGRectElement>;
+      stop: React.SVGProps<SVGStopElement>;
+      switch: React.SVGProps<SVGSwitchElement>;
+      symbol: React.SVGProps<SVGSymbolElement>;
+      text: React.SVGProps<SVGTextElement>;
+      textPath: React.SVGProps<SVGTextPathElement>;
+      tspan: React.SVGProps<SVGTSpanElement>;
+      use: React.SVGProps<SVGUseElement>;
+      view: React.SVGProps<SVGViewElement>;
+    }
+  }
+}

--- a/src/examples/advanced.ts
+++ b/src/examples/advanced.ts
@@ -7,7 +7,7 @@ export const queryCode = `query {
   }
 }`;
 
-export const reactCode = `import React from 'react'
+export const reactCode = `import * as React from 'react'
 import { useTina } from 'tinacms/dist/edit-state'
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 
@@ -53,7 +53,7 @@ export default function Page(props) {
   )
 }`;
 
-export const schemaCode = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{

--- a/src/examples/basic.ts
+++ b/src/examples/basic.ts
@@ -19,7 +19,7 @@ export const wrapCodeNoImport = (
   queryCode: string,
   importItem: string
 ) => {
-  return `import React from 'react'
+  return `import * as React from 'react'
 ${importItem}
 
 export default function Page(props) {
@@ -68,7 +68,7 @@ export const reactCode = wrapCode(
   queryCode
 );
 
-export const schemaCode = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{

--- a/src/examples/object.ts
+++ b/src/examples/object.ts
@@ -13,7 +13,7 @@ export const queryCode = `query {
   }
 }`;
 
-export const schemaCode = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -106,7 +106,7 @@ testimonials:
     quote: Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo expedita voluptas culpa sapiente alias molestiae. Numquam corrupti in laborum sed rerum et corporis.
 ---`;
 
-export const schemaCodeWithData = `import { defineSchema } from '@tinacms/cli'
+export const schemaCodeWithData = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -217,7 +217,7 @@ pageBlocks:
     _template: testimonial
 ---`;
 
-export const schemaCodeBlock = `import { defineSchema } from '@tinacms/cli'
+export const schemaCodeBlock = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{

--- a/src/examples/reference.ts
+++ b/src/examples/reference.ts
@@ -14,7 +14,7 @@ export const queryCode = `query {
   }
 }`;
 
-export const reactCode = `import React from 'react'
+export const reactCode = `import * as React from 'react'
 import { useTina } from 'tinacms/dist/edit-state'
 
 export default function Page(props) {
@@ -78,7 +78,7 @@ export default function Page(props) {
   )
 }`;
 
-export const schemaCode = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{

--- a/src/examples/rich-text.ts
+++ b/src/examples/rich-text.ts
@@ -9,7 +9,7 @@ export const queryCode = `query {
   }
 }`;
 
-export const reactCode = `import React from 'react'
+export const reactCode = `import * as React from 'react'
 import { useTina } from 'tinacms/dist/edit-state'
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 
@@ -56,7 +56,7 @@ export default function Page(props) {
     </div>
   )
 }`;
-export const reactCodeExperimental = `import React from 'react'
+export const reactCodeExperimental = `import * as React from 'react'
 import { useTina } from 'tinacms/dist/edit-state'
 import { useCMS } from 'tinacms'
 import { TinaMarkdown } from "tinacms/dist/rich-text";
@@ -109,7 +109,7 @@ export default function Page(props) {
   )
 }`;
 
-export const schemaCode = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{

--- a/src/examples/scalars.ts
+++ b/src/examples/scalars.ts
@@ -9,7 +9,7 @@ export const queryCode = `query {
   }
 }`;
 
-export const schemaCode = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -59,7 +59,7 @@ export const queryCode2 = `query {
   }
 }`;
 
-export const schemaCode2 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode2 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -102,7 +102,7 @@ export const datetime = {
   section: "middle",
 };
 
-export const schemaCodeFormatted = `import { defineSchema } from '@tinacms/cli'
+export const schemaCodeFormatted = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -140,7 +140,7 @@ export const queryCode3 = `query {
   }
 }`;
 
-export const schemaCode3 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode3 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{

--- a/src/examples/string.ts
+++ b/src/examples/string.ts
@@ -44,7 +44,7 @@ export const reactCode2 = `return (
   </div>
 );`;
 
-export const schemaCode2 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode2 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -96,7 +96,7 @@ export const reactCode3 = `return (
   </div>
 );`;
 
-export const schemaCode3 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode3 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -154,7 +154,7 @@ export const reactCode4 = `return (
   </div>
 );`;
 
-export const schemaCode4 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode4 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -196,7 +196,7 @@ export const stringListOptions = {
   section: "middle",
 };
 
-export const schemaCode5 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode5 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -261,7 +261,7 @@ export const stringBody = {
   section: "middle",
 };
 
-export const schemaCode6 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode6 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -314,7 +314,7 @@ export const stringTextarea = {
   section: "middle",
 };
 
-export const schemaCode7 = `import { defineSchema } from '@tinacms/cli'
+export const schemaCode7 = `import { defineSchema } from 'tinacms'
 
 export default defineSchema({
   collections: [{
@@ -336,7 +336,7 @@ export const markdownCode7 = `---
 ---
 `;
 
-export const reactCode7 = `import React from 'react'
+export const reactCode7 = `import * as React from 'react'
 import { useCMS, wrapFieldsWithMeta } from 'tinacms'
 import { useTina } from 'tinacms/dist/edit-state'
 

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -14,11 +14,9 @@ export const fetcher = async ({
   const res = await fetch(
     `${API_URL}?schema=${encodeURIComponent(
       JSON.stringify(schemaCode)
-    )}&content=${encodeURIComponent(
-      markdownCode
-    )}&query=${queryCode}&variables=${encodeURIComponent(
-      JSON.stringify(variables)
-    )}`
+    )}&content=${encodeURIComponent(markdownCode)}&query=${encodeURIComponent(
+      queryCode
+    )}&variables=${encodeURIComponent(JSON.stringify(variables))}`
   );
 
   const json = await res.json();

--- a/src/tina.tsx
+++ b/src/tina.tsx
@@ -5,6 +5,7 @@ import {
   TinaProvider,
   TinaDataProvider,
 } from "tinacms";
+import { TinaSchema, addNamespaceToSchema } from "@tinacms/schema-tools";
 import * as richtext from "tinacms/dist/rich-text";
 import * as tinacms from "tinacms";
 import { executeCode } from "./compile";
@@ -13,7 +14,6 @@ import { fetcher } from "./fetcher";
 
 const deps = {
   react: React,
-  "@tinacms/cli": { defineSchema: (obj: object) => obj },
   "tinacms/dist/rich-text": richtext,
   tinacms: tinacms,
 };
@@ -37,6 +37,12 @@ class MockClient extends LocalClient {
   async request(query: string, options: { variables: object }) {
     try {
       const schemaObj = (await executeCode(this.schemaCode, deps)) as object;
+      // @ts-ignore
+      this.schema = new TinaSchema({
+        version: { fullVersion: "", major: "", minor: "", patch: "" },
+        meta: { flags: [] },
+        ...addNamespaceToSchema(schemaObj, []),
+      });
       const res = await fetcher({
         schemaCode: schemaObj,
         markdownCode: this.markdownCode,
@@ -75,7 +81,7 @@ export const FakeTina = (props: {
     const cms = new TCMS({
       enabled: true,
       sidebar: {
-        displayMode: "overlay",
+        // displayMode: "overlay",
       },
     });
     cms.registerApi(

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,14 +550,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/runtime-corejs2@^7.4.5":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.16.3.tgz#26064188b2cb843121a58b6343b68812bfb94b88"
-  integrity sha512-VrmNH31CEUoR7kIel005qFMVUJpJm1VxfM7YUzVVc2jrxHCi/I6lBEJuqAcP9u9nEzmTD2RnSPhzfdupcSbnPQ==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
@@ -868,6 +860,15 @@
     relay-compiler "12.0.0"
     tslib "~2.3.0"
 
+"@graphql-tools/relay-operation-optimizer@^6.4.1":
+  version "6.4.9"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.9.tgz#f3e1960ac8e6429a09156836701a03ebf523f0e1"
+  integrity sha512-fHMR1bNyx+ryBnmtXWnYmxvQLEx0O3yIG0MTVB1Mp6GlsyKTGI3O9njvjv0EI2JmCszs1uakT/6BW0LO37E6tQ==
+  dependencies:
+    "@graphql-tools/utils" "8.6.9"
+    relay-compiler "12.0.0"
+    tslib "~2.3.0"
+
 "@graphql-tools/schema@8.3.1", "@graphql-tools/schema@^8.1.2", "@graphql-tools/schema@^8.3.1":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.1.tgz#1ee9da494d2da457643b3c93502b94c3c4b68c74"
@@ -910,6 +911,13 @@
   dependencies:
     tslib "~2.3.0"
 
+"@graphql-tools/utils@8.6.9":
+  version "8.6.9"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.9.tgz#fe1b81df29c9418b41b7a1ffe731710b93d3a1fe"
+  integrity sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==
+  dependencies:
+    tslib "~2.3.0"
+
 "@graphql-tools/wrap@^8.3.1":
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-8.3.2.tgz#d3bcecb7529d071e4ecc4dfc75b9566e3da79d4f"
@@ -926,10 +934,15 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
-"@headlessui/react@^1.4.1", "@headlessui/react@^1.4.2":
+"@headlessui/react@^1.4.2":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.4.2.tgz#87e264f190dbebbf8dfdd900530da973dad24576"
   integrity sha512-N8tv7kLhg9qGKBkVdtg572BvKvWhmiudmeEpOCyNwzOsZHCXBtl8AazGikIfUS+vBoub20Fse3BjawXDVPPdug==
+
+"@headlessui/react@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
+  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
 
 "@heroicons/react@^1.0.4", "@heroicons/react@^1.0.5":
   version "1.0.5"
@@ -1015,6 +1028,18 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
 "@n1ru4l/graphql-live-query@^0.9.0":
   version "0.9.0"
@@ -1411,10 +1436,10 @@
     hex-rgb "^4.1.0"
     postcss-selector-parser "^6.0.2"
 
-"@tinacms/cli@^0.58.2":
-  version "0.58.2"
-  resolved "https://registry.yarnpkg.com/@tinacms/cli/-/cli-0.58.2.tgz#862a88c63da61e122679c0defde3b88784279a8d"
-  integrity sha512-Cy2j7du9QnQROGTZQscuKKxs0Yic17pNTrpqTDeFtK5LjkZ13vePgBdEGgkYs6WhEuY2C6D1BQSKg2MHblhyJw==
+"@tinacms/cli@^0.60.12":
+  version "0.60.12"
+  resolved "https://registry.yarnpkg.com/@tinacms/cli/-/cli-0.60.12.tgz#51cf87e172a86211d00fe0200898cdd75fb1cc4c"
+  integrity sha512-1XD4OpKMUR6MdD3npD9yG0DW30tZwTVeK3Pc0KoiSE21xZzcD0VT+YBUcvSjRCqwAuBwstjdIUEdQ7OGzO/O+Q==
   dependencies:
     "@graphql-codegen/core" "^2.1.0"
     "@graphql-codegen/plugin-helpers" latest
@@ -1424,16 +1449,22 @@
     "@graphql-codegen/visitor-plugin-common" "^2.4.0"
     "@graphql-tools/graphql-file-loader" "^7.2.0"
     "@graphql-tools/load" "^7.3.2"
-    "@tinacms/graphql" "0.58.2"
+    "@tinacms/datalayer" "0.1.1"
+    "@tinacms/graphql" "0.59.11"
+    "@tinacms/metrics" "0.0.3"
+    "@tinacms/schema-tools" "0.0.3"
+    "@yarnpkg/esbuild-plugin-pnp" "^2.0.1-rc.3"
+    add "^2.0.6"
     ajv "^6.12.3"
     altair-express-middleware "4.0.6"
     auto-bind "^4.0.0"
-    axios "0.19.0"
+    axios "0.21.2"
     body-parser "^1.19.0"
     chalk "^2.4.2"
     chokidar "^3.5.1"
-    commander "5.1.0"
+    commander "^9.0.0"
     cors "^2.8.5"
+    esbuild "^0.14.20"
     esm "3.2.25"
     express "^4.17.1"
     fast-glob "^3.2.4"
@@ -1442,21 +1473,44 @@
     js-yaml "^4.0.0"
     lodash "^4.17.19"
     lodash.get "^4.4.2"
-    log4js "^6.3.0"
+    log4js "^6.4.0"
     normalize-path "^3.0.0"
     progress "^2.0.3"
     prompts "^2.4.1"
-    typescript "^4.3.5"
+    yarn "^1.22.17"
     yup "^0.32.9"
 
-"@tinacms/graphql@0.58.2":
-  version "0.58.2"
-  resolved "https://registry.yarnpkg.com/@tinacms/graphql/-/graphql-0.58.2.tgz#a3f1416fe5607d6d3abe36b5d611db646751acdb"
-  integrity sha512-h/0i7GNtTDsauH/n1RpLG4kP+EjtaCEfptc+7r76iE/KbA68nqv3yHkXzGGYo2Ch7Fd9BwQI0JYNMDcrhFdZcw==
+"@tinacms/datalayer@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tinacms/datalayer/-/datalayer-0.1.1.tgz#b68ca33b91f2759852353b6fad68a8eb4cf6d806"
+  integrity sha512-RDe1b8LqiJm2ztv2Cw8fM3kIVwQDf6bjJNnkKTu+5dM1M6CA86XXfXMhmtwnBGI/4QVlGLnF8eoYDK5Gva4DmA==
   dependencies:
     "@octokit/auth-app" "^2.6.0"
     "@octokit/graphql" "^4.5.6"
     "@octokit/rest" "18.0.6"
+    encoding-down "^7.1.0"
+    fast-glob "^3.2.5"
+    fs-extra "^9.0.1"
+    graphql "^15.3.0"
+    gray-matter "^4.0.2"
+    js-yaml "^3.14.0"
+    jsonpath-plus "^6.0.1"
+    level "^7.0.1"
+    leveldown "^6.1.0"
+    levelup "^5.1.1"
+    lodash "^4.17.20"
+    memdown "^6.1.1"
+    normalize-path "^3.0.0"
+    prettier "^2.2.1"
+    yup "^0.32.9"
+
+"@tinacms/graphql@0.59.11":
+  version "0.59.11"
+  resolved "https://registry.yarnpkg.com/@tinacms/graphql/-/graphql-0.59.11.tgz#bf30609d4e83f4560ef439c0606953dbf04bcf4d"
+  integrity sha512-pJeO52s5ffjsDdGNQHvwQBzledf6mnyYCrIshw/PsFhIZzaURQxNFYJU/x4QSPU+NmVKm63QMiTVIS6qIrjrbw==
+  dependencies:
+    "@graphql-tools/relay-operation-optimizer" "^6.4.1"
+    "@tinacms/datalayer" "0.1.1"
     body-parser "^1.19.0"
     cors "^2.8.5"
     dataloader "^2.0.0"
@@ -1472,17 +1526,14 @@
     graphql-type-json "^0.3.2"
     gray-matter "^4.0.2"
     js-yaml "^3.14.0"
-    level "^7.0.1"
-    levelup "^5.1.1"
+    leveldown "^6.1.0"
     lodash "^4.17.20"
     mdast "^3.0.0"
     mdast-util-from-markdown "^1.0.0"
     mdast-util-mdx "^1.1.0"
     mdast-util-mdx-expression "^1.1.0"
     mdast-util-to-markdown "^1.2.1"
-    memdown "^6.1.1"
     micromark-extension-mdxjs "^1.0.0"
-    mocha "^9.1.1"
     normalize-path "^3.0.0"
     prettier "^2.2.1"
     rehype-format "^3.1.0"
@@ -1501,26 +1552,40 @@
     ws "^7.3.1"
     yup "^0.32.9"
 
-"@tinacms/sharedctx@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tinacms/sharedctx/-/sharedctx-0.1.0.tgz#1ca290ac96f394362d07b625164a30b85194cc97"
-  integrity sha512-iorVcydqFDsjDp/PMaN4y0kF15qTTfHDd00fUN3wgW9h2fOmCu3o0KjC4yjrDyLnCdA0pHivpbPvOg3kLmCXog==
+"@tinacms/metrics@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@tinacms/metrics/-/metrics-0.0.3.tgz#aa97344f54c27a0f06559e1e715e94a5e622c388"
+  integrity sha512-qopRyLvkbNuHuZGHdXsJ6M1DxtB65aecDIf8s8XZP9l6NfEfmWPC4/1uMYgG4PtTLgRymprM0l51XLqneq+5Ng==
+  dependencies:
+    isomorphic-fetch "^3.0.0"
 
-"@tinacms/toolkit@0.56.12":
-  version "0.56.12"
-  resolved "https://registry.yarnpkg.com/@tinacms/toolkit/-/toolkit-0.56.12.tgz#97cad1942ea0374fe14892faea8921f8aae6d54e"
-  integrity sha512-rsagZhkLrHAGxdGkZrp5rZuYC+6FyTX6F+Z52hDeX3HTsjYFo+coUUPYSNbcd3k3w66PGVn9eeFUimNzRDt81A==
+"@tinacms/schema-tools@0.0.3", "@tinacms/schema-tools@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@tinacms/schema-tools/-/schema-tools-0.0.3.tgz#8d2887e75b44b7d00dccbe2c2e28021568246c88"
+  integrity sha512-PGE1WxfJkiBDJK7/m3MIqWIAVaS17R7rnGN1nWWuatkaHz93eJNqFMAnAQzpTTB91cgRYF1NaJS60Z5UQZN5HA==
+  dependencies:
+    zod "^3.14.3"
+
+"@tinacms/sharedctx@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tinacms/sharedctx/-/sharedctx-0.1.1.tgz#8ca3446348b87653095a4a3bda797ddaa65d4d38"
+  integrity sha512-+23d5EWdj34p/fYTYn+R2QOt8hn5qqirH7/o2cWYhY1ywCi/gZbCjzRXyi7PxBMh4fH1lFZuO5zseZrIWgmodA==
+
+"@tinacms/toolkit@0.56.21":
+  version "0.56.21"
+  resolved "https://registry.yarnpkg.com/@tinacms/toolkit/-/toolkit-0.56.21.tgz#77f8abbb628ef672e37384c93caa78bcf29dbad3"
+  integrity sha512-hgaz2X26406ZWPYK5l2Y6bkZ32nnLqBUQBH4KeCPBtvAb7SrZd/EWHf5AoB1I816ExrWkCmv7S3tn6cXiNzzvQ==
   dependencies:
     "@floating-ui/dom" "^0.1.7"
     "@floating-ui/react-dom" "^0.3.3"
-    "@headlessui/react" "^1.4.2"
+    "@headlessui/react" "^1.5.0"
     "@heroicons/react" "^1.0.5"
     "@react-aria/i18n" "^3.3.4"
     "@react-aria/listbox" "3.3.0"
     "@react-types/combobox" "^3.2.0"
     "@react-types/shared" "^3.10.0"
     "@sambego/storybook-styles" "^1.0.0"
-    "@tinacms/sharedctx" "0.1.0"
+    "@tinacms/sharedctx" "0.1.1"
     "@types/atob" "^2.1.2"
     "@types/cors" "^2.8.12"
     "@types/express" "^4.17.13"
@@ -1555,19 +1620,20 @@
     express "^4.17.1"
     final-form "^4.20.2"
     final-form-arrays "^3.0.1"
+    final-form-set-field-data "^1.0.2"
     is-hotkey "^0.2.0"
     lodash.get "^4.4.2"
     moment ">=2 <=3"
     multer "1.4.2"
     path "^0.12.7"
     prop-types "15.7.2"
-    react-beautiful-dnd "^11.0.5"
+    react-beautiful-dnd "^13.1.0"
     react-color "^2.17.3"
     react-datetime "^2.16.3"
     react-dropzone "10.1.8"
     react-final-form "^6.3.0"
     react-icons "^4.3.1"
-    simple-git "1.126.0"
+    simple-git "3.5.0"
     slate "^0.66.0"
     slate-history "^0.66.0"
     slate-hyperscript "^0.66.0"
@@ -2677,11 +2743,6 @@
   dependencies:
     immer "9.0.6"
 
-"@ungap/promise-all-settled@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
-  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
-
 "@vitejs/plugin-react@^1.0.7":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.1.1.tgz#5a242c64fa0a588e5b203938e5bd6d05fa25edf2"
@@ -2736,6 +2797,13 @@
   version "1.9.5"
   resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
   integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
+
+"@yarnpkg/esbuild-plugin-pnp@^2.0.1-rc.3":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/esbuild-plugin-pnp/-/esbuild-plugin-pnp-2.0.1.tgz#120faad903d40e8f000ed3c9db9f9055c9612800"
+  integrity sha512-M8nYJr8S0riwy4Jgm3ja88m5ZfW6zZSV8fgLtO1mXpwTg0tD9ki1ShPOSm9DEbicc350TVf+k/jVNh6v1xApCw==
+  dependencies:
+    tslib "^1.13.0"
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -2798,6 +2866,11 @@ actioncable@^5.2.6:
   resolved "https://registry.yarnpkg.com/actioncable/-/actioncable-5.2.6.tgz#cea30647183524f3bae8c2a78fa6ecd6d4dbc70c"
   integrity sha512-ofLHm57nN24zghkl+tQe6IVrZeSJ655lNLQjNQJvtQkeTDqlF30McuMB4o9DqpxdHgW/w0RNWaAQHB6VPlleNQ==
 
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
+
 ajv@^6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -2845,11 +2918,6 @@ altair-static@^4.0.6:
   integrity sha512-d8yuWgzG68XS846QzRhxJR4KDXFjXA3RJrtcXwHMi9RkKHYqgbOGrydLYcQWEYjOryCdXOsuZ7T88NkANaddiA==
   dependencies:
     altair-graphql-core "^4.2.1"
-
-ansi-colors@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -3073,13 +3141,12 @@ aws-appsync-subscription-link@^3.0.3:
     debug "2.6.9"
     url "^0.11.0"
 
-axios@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+axios@0.21.2:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
+  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
   dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
+    follow-redirects "^1.14.0"
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -3313,11 +3380,6 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browser-stdout@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
-  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
-
 browserslist@^4.17.5:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
@@ -3426,11 +3488,6 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
-  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
-
 camelize@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
@@ -3478,7 +3535,7 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3560,7 +3617,7 @@ character-reference-invalid@^2.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
   integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
-chokidar@3.5.2, chokidar@^3.5.1, chokidar@^3.5.2:
+chokidar@^3.5.1, chokidar@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -3598,15 +3655,6 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
-
-cliui@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
 
 clsx@1.1.1, clsx@^1.1.1:
   version "1.1.1"
@@ -3658,15 +3706,15 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
 commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@^9.0.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
+  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
 
 common-tags@1.8.0:
   version "1.8.0"
@@ -3756,7 +3804,7 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
-core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.5.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
@@ -3831,7 +3879,7 @@ crypto-js@^4.0.0:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
   integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
-css-box-model@^1.1.2:
+css-box-model@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
   integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
@@ -3898,15 +3946,10 @@ date-fns@^2.21.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
   integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
 
-date-format@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
-  integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
-
-date-format@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-3.0.0.tgz#eb8780365c7d2b1511078fb491e6479780f3ad95"
-  integrity sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==
+date-format@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.7.tgz#aa1cf4400badfe693c8462bbfcba43ab821d7d14"
+  integrity sha512-k5xqlzDGIfv2N/DHR/BR8Kc4N9CRy9ReuDkmdxeX/jNfit94QXd36emWMm40ZOEDKNm/c91yV9EO3uGPkR7wWQ==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -3915,24 +3958,17 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
-
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.0, debug@^4.1.0:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.1.1, debug@^4.3.3, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -3940,11 +3976,6 @@ decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
-
-decamelize@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
-  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 decode-named-character-reference@^1.0.0:
   version "1.0.1"
@@ -4057,15 +4088,15 @@ didyoumean@^1.2.2:
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
-diff@5.0.0, diff@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
-
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4210,30 +4241,60 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+esbuild-android-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.36.tgz#fc5f95ce78c8c3d790fa16bc71bd904f2bb42aa1"
+  integrity sha512-jwpBhF1jmo0tVCYC/ORzVN+hyVcNZUWuozGcLHfod0RJCedTDTvR4nwlTXdx1gtncDqjk33itjO+27OZHbiavw==
+
 esbuild-android-arm64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz#3fc3ff0bab76fe35dd237476b5d2b32bb20a3d44"
   integrity sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==
+
+esbuild-android-arm64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.36.tgz#44356fbb9f8de82a5cdf11849e011dfb3ad0a8a8"
+  integrity sha512-/hYkyFe7x7Yapmfv4X/tBmyKnggUmdQmlvZ8ZlBnV4+PjisrEhAvC3yWpURuD9XoB8Wa1d5dGkTsF53pIvpjsg==
 
 esbuild-darwin-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz#8e9169c16baf444eacec60d09b24d11b255a8e72"
   integrity sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==
 
+esbuild-darwin-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.36.tgz#3d9324b21489c70141665c2e740d6e84f16f725d"
+  integrity sha512-kkl6qmV0dTpyIMKagluzYqlc1vO0ecgpviK/7jwPbRDEv5fejRTaBBEE2KxEQbTHcLhiiDbhG7d5UybZWo/1zQ==
+
 esbuild-darwin-arm64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz#1b07f893b632114f805e188ddfca41b2b778229a"
   integrity sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==
+
+esbuild-darwin-arm64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.36.tgz#2a8040c2e465131e5281034f3c72405e643cb7b2"
+  integrity sha512-q8fY4r2Sx6P0Pr3VUm//eFYKVk07C5MHcEinU1BjyFnuYz4IxR/03uBbDwluR6ILIHnZTE7AkTUWIdidRi1Jjw==
 
 esbuild-freebsd-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz#0b8b7eca1690c8ec94c75680c38c07269c1f4a85"
   integrity sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==
 
+esbuild-freebsd-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.36.tgz#d82c387b4d01fe9e8631f97d41eb54f2dbeb68a3"
+  integrity sha512-Hn8AYuxXXRptybPqoMkga4HRFE7/XmhtlQjXFHoAIhKUPPMeJH35GYEUWGbjteai9FLFvBAjEAlwEtSGxnqWww==
+
 esbuild-freebsd-arm64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz#2e1a6c696bfdcd20a99578b76350b41db1934e52"
   integrity sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==
+
+esbuild-freebsd-arm64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.36.tgz#e8ce2e6c697da6c7ecd0cc0ac821d47c5ab68529"
+  integrity sha512-S3C0attylLLRiCcHiJd036eDEMOY32+h8P+jJ3kTcfhJANNjP0TNBNL30TZmEdOSx/820HJFgRrqpNAvTbjnDA==
 
 esbuild-jest@^0.5.0:
   version "0.5.0"
@@ -4249,45 +4310,100 @@ esbuild-linux-32@0.13.15:
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz#6fd39f36fc66dd45b6b5f515728c7bbebc342a69"
   integrity sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==
 
+esbuild-linux-32@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.36.tgz#a4a261e2af91986ea62451f2db712a556cb38a15"
+  integrity sha512-Eh9OkyTrEZn9WGO4xkI3OPPpUX7p/3QYvdG0lL4rfr73Ap2HAr6D9lP59VMF64Ex01LhHSXwIsFG/8AQjh6eNw==
+
 esbuild-linux-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz#9cb8e4bcd7574e67946e4ee5f1f1e12386bb6dd3"
   integrity sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==
+
+esbuild-linux-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.36.tgz#4a9500f9197e2c8fcb884a511d2c9d4c2debde72"
+  integrity sha512-vFVFS5ve7PuwlfgoWNyRccGDi2QTNkQo/2k5U5ttVD0jRFaMlc8UQee708fOZA6zTCDy5RWsT5MJw3sl2X6KDg==
 
 esbuild-linux-arm64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz#3891aa3704ec579a1b92d2a586122e5b6a2bfba1"
   integrity sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==
 
+esbuild-linux-arm64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.36.tgz#c91c21e25b315464bd7da867365dd1dae14ca176"
+  integrity sha512-24Vq1M7FdpSmaTYuu1w0Hdhiqkbto1I5Pjyi+4Cdw5fJKGlwQuw+hWynTcRI/cOZxBcBpP21gND7W27gHAiftw==
+
 esbuild-linux-arm@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz#8a00e99e6a0c6c9a6b7f334841364d8a2b4aecfe"
   integrity sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==
+
+esbuild-linux-arm@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.36.tgz#90e23bca2e6e549affbbe994f80ba3bb6c4d934a"
+  integrity sha512-NhgU4n+NCsYgt7Hy61PCquEz5aevI6VjQvxwBxtxrooXsxt5b2xtOUXYZe04JxqQo+XZk3d1gcr7pbV9MAQ/Lg==
 
 esbuild-linux-mips64le@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz#36b07cc47c3d21e48db3bb1f4d9ef8f46aead4f7"
   integrity sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==
 
+esbuild-linux-mips64le@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.36.tgz#40e11afb08353ff24709fc89e4db0f866bc131d2"
+  integrity sha512-hZUeTXvppJN+5rEz2EjsOFM9F1bZt7/d2FUM1lmQo//rXh1RTFYzhC0txn7WV0/jCC7SvrGRaRz0NMsRPf8SIA==
+
 esbuild-linux-ppc64le@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz#f7e6bba40b9a11eb9dcae5b01550ea04670edad2"
   integrity sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==
+
+esbuild-linux-ppc64le@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.36.tgz#9e8a588c513d06cc3859f9dcc52e5fdfce8a1a5e"
+  integrity sha512-1Bg3QgzZjO+QtPhP9VeIBhAduHEc2kzU43MzBnMwpLSZ890azr4/A9Dganun8nsqD/1TBcqhId0z4mFDO8FAvg==
+
+esbuild-linux-riscv64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.36.tgz#e578c09b23b3b97652e60e3692bfda628b541f06"
+  integrity sha512-dOE5pt3cOdqEhaufDRzNCHf5BSwxgygVak9UR7PH7KPVHwSTDAZHDoEjblxLqjJYpc5XaU9+gKJ9F8mp9r5I4A==
+
+esbuild-linux-s390x@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.36.tgz#3c9dab40d0d69932ffded0fd7317bb403626c9bc"
+  integrity sha512-g4FMdh//BBGTfVHjF6MO7Cz8gqRoDPzXWxRvWkJoGroKA18G9m0wddvPbEqcQf5Tbt2vSc1CIgag7cXwTmoTXg==
 
 esbuild-netbsd-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz#a2fedc549c2b629d580a732d840712b08d440038"
   integrity sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==
 
+esbuild-netbsd-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.36.tgz#e27847f6d506218291619b8c1e121ecd97628494"
+  integrity sha512-UB2bVImxkWk4vjnP62ehFNZ73lQY1xcnL5ZNYF3x0AG+j8HgdkNF05v67YJdCIuUJpBuTyCK8LORCYo9onSW+A==
+
 esbuild-openbsd-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz#b22c0e5806d3a1fbf0325872037f885306b05cd7"
   integrity sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==
 
+esbuild-openbsd-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.36.tgz#c94c04c557fae516872a586eae67423da6d2fabb"
+  integrity sha512-NvGB2Chf8GxuleXRGk8e9zD3aSdRO5kLt9coTQbCg7WMGXeX471sBgh4kSg8pjx0yTXRt0MlrUDnjVYnetyivg==
+
 esbuild-sunos-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz#d0b6454a88375ee8d3964daeff55c85c91c7cef4"
   integrity sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==
+
+esbuild-sunos-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.36.tgz#9b79febc0df65a30f1c9bd63047d1675511bf99d"
+  integrity sha512-VkUZS5ftTSjhRjuRLp+v78auMO3PZBXu6xl4ajomGenEm2/rGuWlhFSjB7YbBNErOchj51Jb2OK8lKAo8qdmsQ==
 
 esbuild-wasm@^0.14.2:
   version "0.14.3"
@@ -4299,15 +4415,30 @@ esbuild-windows-32@0.13.15:
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz#c96d0b9bbb52f3303322582ef8e4847c5ad375a7"
   integrity sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==
 
+esbuild-windows-32@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.36.tgz#910d11936c8d2122ffdd3275e5b28d8a4e1240ec"
+  integrity sha512-bIar+A6hdytJjZrDxfMBUSEHHLfx3ynoEZXx/39nxy86pX/w249WZm8Bm0dtOAByAf4Z6qV0LsnTIJHiIqbw0w==
+
 esbuild-windows-64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz#1f79cb9b1e1bb02fb25cd414cb90d4ea2892c294"
   integrity sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==
 
+esbuild-windows-64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.36.tgz#21b4ce8b42a4efc63f4b58ec617f1302448aad26"
+  integrity sha512-+p4MuRZekVChAeueT1Y9LGkxrT5x7YYJxYE8ZOTcEfeUUN43vktSn6hUNsvxzzATrSgq5QqRdllkVBxWZg7KqQ==
+
 esbuild-windows-arm64@0.13.15:
   version "0.13.15"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz#482173070810df22a752c686509c370c3be3b3c3"
   integrity sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==
+
+esbuild-windows-arm64@0.14.36:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.36.tgz#ba21546fecb7297667d0052d00150de22c044b24"
+  integrity sha512-fBB4WlDqV1m18EF/aheGYQkQZHfPHiHJSBYzXIo8yKehek+0BtBwo/4PNwKGJ5T0YK0oc8pBKjgwPbzSrPLb+Q==
 
 esbuild@^0.12.25:
   version "0.12.29"
@@ -4337,6 +4468,32 @@ esbuild@^0.13.12:
     esbuild-windows-64 "0.13.15"
     esbuild-windows-arm64 "0.13.15"
 
+esbuild@^0.14.20:
+  version "0.14.36"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.36.tgz#0023a73eab57886ac5605df16ee421e471a971b3"
+  integrity sha512-HhFHPiRXGYOCRlrhpiVDYKcFJRdO0sBElZ668M4lh2ER0YgnkLxECuFe7uWCf23FrcLc59Pqr7dHkTqmRPDHmw==
+  optionalDependencies:
+    esbuild-android-64 "0.14.36"
+    esbuild-android-arm64 "0.14.36"
+    esbuild-darwin-64 "0.14.36"
+    esbuild-darwin-arm64 "0.14.36"
+    esbuild-freebsd-64 "0.14.36"
+    esbuild-freebsd-arm64 "0.14.36"
+    esbuild-linux-32 "0.14.36"
+    esbuild-linux-64 "0.14.36"
+    esbuild-linux-arm "0.14.36"
+    esbuild-linux-arm64 "0.14.36"
+    esbuild-linux-mips64le "0.14.36"
+    esbuild-linux-ppc64le "0.14.36"
+    esbuild-linux-riscv64 "0.14.36"
+    esbuild-linux-s390x "0.14.36"
+    esbuild-netbsd-64 "0.14.36"
+    esbuild-openbsd-64 "0.14.36"
+    esbuild-sunos-64 "0.14.36"
+    esbuild-windows-32 "0.14.36"
+    esbuild-windows-64 "0.14.36"
+    esbuild-windows-arm64 "0.14.36"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -4346,11 +4503,6 @@ escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
-
-escape-string-regexp@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -4615,6 +4767,11 @@ final-form-arrays@^3.0.1:
   resolved "https://registry.yarnpkg.com/final-form-arrays/-/final-form-arrays-3.0.2.tgz#9f3bef778dec61432357744eb6f3abef7e7f3847"
   integrity sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==
 
+final-form-set-field-data@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/final-form-set-field-data/-/final-form-set-field-data-1.0.2.tgz#ce19095af5d607148c1e6ce3403d75d40223d848"
+  integrity sha512-gAnENimyQ5GW3OEGca5pbwm4lYshW2orzfBlPUYqzcm7ZxkQrVO8FqCAgEcCM+Rq9U1OU0q+D+UkqETvvDY6jw==
+
 final-form@4.20.1:
   version "4.20.1"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.1.tgz#525a7f7f27f55c28d8994b157b24d6104fc560e9"
@@ -4642,14 +4799,6 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-up@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -4663,17 +4812,15 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+flatted@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
+follow-redirects@^1.14.0:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -4725,14 +4872,14 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+fs-extra@^10.0.1:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
   dependencies:
     graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.0.1:
   version "9.1.0"
@@ -4769,7 +4916,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1, get-caller-file@^2.0.5:
+get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -4826,18 +4973,6 @@ glob@7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@7.1.7:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4984,11 +5119,6 @@ gray-matter@^4.0.2:
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
 
-growl@1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
-  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
@@ -5109,11 +5239,6 @@ hast-util-whitespace@^1.0.0, hast-util-whitespace@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz#e4fe77c4a9ae1cb2e6c25e02df0043d0164f6e41"
   integrity sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==
-
-he@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 header-case@^2.0.4:
   version "2.0.4"
@@ -5408,7 +5533,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0, is-buffer@^2.0.2, is-buffer@^2.0.5:
+is-buffer@^2.0.0, is-buffer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -5575,7 +5700,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-plain-obj@^2.0.0, is-plain-obj@^2.1.0:
+is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
@@ -5659,11 +5784,6 @@ is-unc-path@^1.0.0:
   dependencies:
     unc-path-regex "^0.1.2"
 
-is-unicode-supported@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
-  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
-
 is-upper-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-2.0.2.tgz#f1105ced1fe4de906a5f39553e7d3803fd804649"
@@ -5714,6 +5834,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 isomorphic-ws@^4.0.1:
   version "4.0.1"
@@ -5811,13 +5939,6 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
-
 js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -5825,6 +5946,13 @@ js-yaml@^3.13.1, js-yaml@^3.14.0:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -5848,13 +5976,6 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -5863,6 +5984,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonpath-plus@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz#9a3e16cedadfab07a3d8dc4e8cd5df4ed8f49c4d"
+  integrity sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==
 
 jsonwebtoken@^8.5.1:
   version "8.5.1"
@@ -6029,13 +6155,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
-
 lodash-es@^4.17.15, lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
@@ -6106,24 +6225,16 @@ lodash@4.17.21, lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
-  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+log4js@^6.4.0:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.4.5.tgz#5cca31b29ece65a625efbc3df6fcbd9cecb9ee7b"
+  integrity sha512-43RJcYZ7nfUxpPO2woTl8CJ0t5+gucLJZ43mtp2PlInT+LygCp/bl6hNJtKulCJ+++fQsjIv4EO3Mp611PfeLQ==
   dependencies:
-    chalk "^4.1.0"
-    is-unicode-supported "^0.1.0"
-
-log4js@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.3.0.tgz#10dfafbb434351a3e30277a00b9879446f715bcb"
-  integrity sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==
-  dependencies:
-    date-format "^3.0.0"
-    debug "^4.1.1"
-    flatted "^2.0.1"
-    rfdc "^1.1.4"
-    streamroller "^2.2.4"
+    date-format "^4.0.7"
+    debug "^4.3.4"
+    flatted "^3.2.5"
+    rfdc "^1.3.0"
+    streamroller "^3.0.7"
 
 loglevel-plugin-prefix@^0.8.4:
   version "0.8.4"
@@ -6389,7 +6500,7 @@ memdown@^6.1.1:
     inherits "^2.0.1"
     ltgt "^2.2.0"
 
-memoize-one@^5.0.4:
+memoize-one@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
@@ -6794,36 +6905,6 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mocha@^9.1.1:
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.1.3.tgz#8a623be6b323810493d8c8f6f7667440fa469fdb"
-  integrity sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==
-  dependencies:
-    "@ungap/promise-all-settled" "1.1.2"
-    ansi-colors "4.1.1"
-    browser-stdout "1.3.1"
-    chokidar "3.5.2"
-    debug "4.3.2"
-    diff "5.0.0"
-    escape-string-regexp "4.0.0"
-    find-up "5.0.0"
-    glob "7.1.7"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "4.1.0"
-    log-symbols "4.1.0"
-    minimatch "3.0.4"
-    ms "2.1.3"
-    nanoid "3.1.25"
-    serialize-javascript "6.0.0"
-    strip-json-comments "3.1.1"
-    supports-color "8.1.1"
-    which "2.0.2"
-    workerpool "6.1.5"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
-    yargs-unparser "2.0.0"
-
 "moment@>=2 <=3":
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
@@ -6863,7 +6944,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1:
+ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -6909,11 +6990,6 @@ nanoclone@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
   integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
-
-nanoid@3.1.25:
-  version "3.1.25"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
-  integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
 
 nanoid@^3.1.30:
   version "3.1.30"
@@ -7108,7 +7184,7 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
-p-limit@3.1.0, p-limit@^3.0.2:
+p-limit@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -7128,13 +7204,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -7470,17 +7539,10 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-raf-schd@^4.0.0:
+raf-schd@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
   integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
-
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -7514,19 +7576,18 @@ re-resizable@^6.9.0, re-resizable@^6.9.1:
   dependencies:
     fast-memoize "^2.5.1"
 
-react-beautiful-dnd@^11.0.5:
-  version "11.0.5"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-11.0.5.tgz#16b1dbd4d6493de0cb3f842cad57c7e9e1ff5fe7"
-  integrity sha512-7llby9U+jIfkINcyxPHVWU0HFYzqxMemUYgGHsFsbx4fZo1n/pW6sYKYzhxGxR3Ap5HxqswcQkKUZX4uEUWhlw==
+react-beautiful-dnd@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz#ec97c81093593526454b0de69852ae433783844d"
+  integrity sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
   dependencies:
-    "@babel/runtime-corejs2" "^7.4.5"
-    css-box-model "^1.1.2"
-    memoize-one "^5.0.4"
-    raf-schd "^4.0.0"
-    react-redux "^7.0.3"
-    redux "^4.0.1"
-    tiny-invariant "^1.0.4"
-    use-memo-one "^1.1.0"
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-color@^2.17.3:
   version "2.19.3"
@@ -7624,10 +7685,10 @@ react-popper@2.2.5, react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-redux@^7.0.3:
-  version "7.2.6"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
-  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+react-redux@^7.2.0:
+  version "7.2.8"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.8.tgz#a894068315e65de5b1b68899f9c6ee0923dd28de"
+  integrity sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==
   dependencies:
     "@babel/runtime" "^7.15.4"
     "@types/react-redux" "^7.1.20"
@@ -7760,10 +7821,17 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-redux@^4.0.0, redux@^4.0.1, redux@^4.1.1:
+redux@^4.0.0, redux@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
   integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
+redux@^4.0.4:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
   dependencies:
     "@babel/runtime" "^7.9.2"
 
@@ -7989,7 +8057,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rfdc@^1.1.4:
+rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
@@ -8053,7 +8121,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -8151,13 +8219,6 @@ sentence-case@^3.0.4:
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
 
-serialize-javascript@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
-  dependencies:
-    randombytes "^2.1.0"
-
 serve-static@1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
@@ -8239,12 +8300,14 @@ signedsource@^1.0.0:
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
   integrity sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=
 
-simple-git@1.126.0:
-  version "1.126.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.126.0.tgz#0c345372275139c8433b8277f4b3e155092aa434"
-  integrity sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==
+simple-git@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.5.0.tgz#3c3538f4d7a1b3c8f3904412b12740bdcad9c8b1"
+  integrity sha512-fZsaq5nzdxQRhMNs6ESGLpMUHoL5GRP+boWPhq9pMYMKwOGZV2jHOxi8AbFFA2Y/6u4kR99HoULizSbpzaODkA==
   dependencies:
-    debug "^4.0.1"
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.3"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -8458,14 +8521,14 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-streamroller@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-2.2.4.tgz#c198ced42db94086a6193608187ce80a5f2b0e53"
-  integrity sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==
+streamroller@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.0.7.tgz#d566353d3d8b5d2f3d813d2df557c08083b414cf"
+  integrity sha512-kh68kwiDGuIPiPDWwRbEC5us+kfARP1e9AsQiaLaSqGrctOvMn0mtL8iNY3r4/o5nIoYi3gPI1jexguZsXDlxw==
   dependencies:
-    date-format "^2.1.0"
-    debug "^4.1.1"
-    fs-extra "^8.1.0"
+    date-format "^4.0.7"
+    debug "^4.3.4"
+    fs-extra "^10.0.1"
 
 streamsearch@0.1.2:
   version "0.1.2"
@@ -8555,11 +8618,6 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
-strip-json-comments@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
-  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
 styled-components@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.3.tgz#312a3d9a549f4708f0fb0edc829eb34bde032743"
@@ -8614,13 +8672,6 @@ sucrase@^3.20.3:
     mz "^2.7.0"
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
-
-supports-color@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
@@ -8716,15 +8767,17 @@ throttle-debounce@^3.0.1:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
-tinacms@0.66.2:
-  version "0.66.2"
-  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.66.2.tgz#176cc51cdc58f54ab932d2f5aac864f29a42d96a"
-  integrity sha512-Duh8b9RHsJ7dW6PgI9Oh+gNfutaWyqfIb/hQ7XJIb7Ly5vmaf/pGo1lDs+n1DcTZK8+wnxmx4vY+NoD/tCRH+w==
+tinacms@^0.67.3:
+  version "0.67.3"
+  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.67.3.tgz#210f6aa7eb0dd31c3d06a734a4e8ba92dc097798"
+  integrity sha512-m09/Ovkwpl/fBl9T1HEbdN0r2qGSbwWXXIbeLdg1O5I1vxJ3epeM4hn0BG2378ST4hEL3luocwpC2ym/LX7j0w==
   dependencies:
-    "@headlessui/react" "^1.4.1"
+    "@graphql-tools/relay-operation-optimizer" "^6.4.1"
+    "@headlessui/react" "^1.5.0"
     "@heroicons/react" "^1.0.4"
-    "@tinacms/sharedctx" "0.1.0"
-    "@tinacms/toolkit" "0.56.12"
+    "@tinacms/schema-tools" "0.0.3"
+    "@tinacms/sharedctx" "0.1.1"
+    "@tinacms/toolkit" "0.56.21"
     crypto-js "^4.0.0"
     final-form "4.20.1"
     graphql "^15.1.0"
@@ -8740,7 +8793,7 @@ tiny-invariant@1.0.6:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
 
-tiny-invariant@^1.0.4, tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
@@ -8904,7 +8957,7 @@ ts-node@^9:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tslib@^1.10.0, tslib@^1.11.1, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -8939,7 +8992,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.5, typescript@^4.4.4:
+typescript@^4.4.4:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
   integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
@@ -9120,11 +9173,6 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -9215,7 +9263,7 @@ use-latest@^1.0.0:
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
 
-use-memo-one@^1.1.0:
+use-memo-one@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
   integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
@@ -9372,6 +9420,11 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 whatwg-url@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
@@ -9408,13 +9461,6 @@ which-typed-array@^1.1.2:
     has-tostringtag "^1.0.0"
     is-typed-array "^1.1.7"
 
-which@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
-
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -9422,24 +9468,10 @@ which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-workerpool@6.1.5:
-  version "6.1.5"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.5.tgz#0f7cf076b6215fd7e1da903ff6f22ddd1886b581"
-  integrity sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==
-
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -9480,11 +9512,6 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
@@ -9495,11 +9522,6 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -9507,34 +9529,6 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
-yargs-unparser@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
-  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
-  dependencies:
-    camelcase "^6.0.0"
-    decamelize "^4.0.0"
-    flat "^5.0.2"
-    is-plain-obj "^2.1.0"
-
-yargs@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
 
 yargs@^15.3.1:
   version "15.4.1"
@@ -9552,6 +9546,11 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yarn@^1.22.17:
+  version "1.22.18"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.18.tgz#05b822ade8c672987bab8858635145da0850f78a"
+  integrity sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==
 
 yn@3.1.1:
   version "3.1.1"
@@ -9595,6 +9594,11 @@ zen-observable@0.8.15, zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zod@^3.14.3:
+  version "3.14.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.14.4.tgz#e678fe9e5469f4663165a5c35c8f3dc66334a5d6"
+  integrity sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==
 
 zustand@3.5.11:
   version "3.5.11"


### PR DESCRIPTION
A series of small to medium changes to the Playground to allow for features provided by the "Extending Tina" changes.

- `tinacms` and `react` types were added and updated
- `schema` is now part of the `MockClient` (matching how `tinacms` works)
- all `examples` have been updated to reflect the changes to `type` (specifically `defineSchema`)
- related packages have been updated
- the `schema.ts` file type is now `schema.tsx` to allow for `ui: { component: {...} }` overrides

Closes https://github.com/tinacms/product-roadmap/issues/112